### PR TITLE
feat: Add Extension methods for `.Returns` of `Task<T>` and `ValueTask<T>`

### DIFF
--- a/src/Mimic.Sandbox/Mimic.Sandbox.csproj
+++ b/src/Mimic.Sandbox/Mimic.Sandbox.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Mimic\Mimic.csproj" />
+        <ProjectReference Include="..\Mimic\Mimic.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Mimic.Sandbox/Program.cs
+++ b/src/Mimic.Sandbox/Program.cs
@@ -4,11 +4,7 @@ var mimic = new Mimic<ITypeToMimic>();
 
 mimic.Setup(m => m.StringMethod(Arg.Any<string>()))
     .Callback(() => Console.WriteLine($"Callback before {nameof(ITypeToMimic.StringMethod)} returns"))
-    .Returns((string a) =>
-    {
-        Console.WriteLine($"The return function for {nameof(ITypeToMimic.StringMethod)} which was called with {a}");
-        return Task.FromResult($"Value is: {a}");
-    })
+    .Returns((string a) => $"Value is: {a}")
     .Callback((string a) => Console.WriteLine($"Callback after {nameof(ITypeToMimic.StringMethod)} returns. Called with {a}"));
 
 bool shouldThrow = false;

--- a/src/Mimic.UnitTests/Mimic.UnitTests.csproj
+++ b/src/Mimic.UnitTests/Mimic.UnitTests.csproj
@@ -9,8 +9,8 @@
     <ItemGroup>
         <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />

--- a/src/Mimic/Extensions/ReturnsExtensions.Generated.cs
+++ b/src/Mimic/Extensions/ReturnsExtensions.Generated.cs
@@ -1,0 +1,182 @@
+using Mimic.Setup.Fluent;
+
+namespace Mimic;
+
+public static partial class ReturnsExtensions
+{
+    #region Task<T>
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2) => Task.FromResult(valueFunction(t1, t2)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3) => Task.FromResult(valueFunction(t1, t2, t3)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4) => Task.FromResult(valueFunction(t1, t2, t3, t4)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)));
+    }
+
+    #endregion
+
+    #region ValueTask<T>
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2) => new ValueTask<TResult>(valueFunction(t1, t2)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3) => new ValueTask<TResult>(valueFunction(t1, t2, t3)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)));
+    }
+
+    #endregion
+}

--- a/src/Mimic/Extensions/ReturnsExtensions.cs
+++ b/src/Mimic/Extensions/ReturnsExtensions.cs
@@ -1,0 +1,52 @@
+﻿using JetBrains.Annotations;
+using Mimic.Setup.Fluent;
+
+namespace Mimic;
+
+[PublicAPI]
+public static partial class ReturnsExtensions
+{
+    #region Task<T>
+
+    public static IReturnsResult<TMimic> Returns<TMimic, TResult>(this IReturns<TMimic, Task<TResult>> mimic, TResult value)
+        where TMimic : class
+    {
+        return mimic.Returns(() => Task.FromResult(value));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns(() => Task.FromResult(valueFunction()));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T, TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<T, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T t) => Task.FromResult(valueFunction(t)));
+    }
+
+    #endregion
+
+    #region ValueTask<T>
+
+    public static IReturnsResult<TMimic> Returns<TMimic, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, TResult value)
+        where TMimic : class
+    {
+        return mimic.Returns(() => new ValueTask<TResult>(value));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns(() => new ValueTask<TResult>(valueFunction()));
+    }
+
+    public static IReturnsResult<TMimic> Returns<TMimic, T, TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<T, TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((T t) => new ValueTask<TResult>(valueFunction(t)));
+    }
+
+    #endregion
+}

--- a/src/Mimic/Extensions/ReturnsExtensions.tt
+++ b/src/Mimic/Extensions/ReturnsExtensions.tt
@@ -1,0 +1,52 @@
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ output extension=".Generated.cs" #>
+using Mimic.Setup.Fluent;
+
+namespace Mimic;
+
+public static partial class ReturnsExtensions
+{
+    #region Task<T>
+
+    <# for (int argumentCount = 2; argumentCount <= 15; argumentCount++) {
+    #>public static IReturnsResult<TMimic> Returns<TMimic, <#
+        for (int i = 1; i <= argumentCount; i++) { #>T<#=i#>, <# }
+        #>TResult>(this IReturns<TMimic, Task<TResult>> mimic, Func<<#
+        for (int i = 1; i <= argumentCount; i++) { #>T<#=i#>, <# } #>TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((<#
+        for (int i = 1; i <= argumentCount; i++)
+        { #>T<#=i#> t<#=i#><#
+            if (i != argumentCount) { #>, <# }
+        } #>) => Task.FromResult(valueFunction(<#
+        for (int i = 1; i <= argumentCount; i++)
+        { #>t<#=i#><#
+            if (i != argumentCount) { #>, <# }
+        } #>)));
+    }
+
+    <# } #>#endregion
+
+    #region ValueTask<T>
+
+    <# for (int argumentCount = 2; argumentCount <= 15; argumentCount++) {
+    #>public static IReturnsResult<TMimic> Returns<TMimic, <#
+        for (int i = 1; i <= argumentCount; i++) { #>T<#=i#>, <# }
+        #>TResult>(this IReturns<TMimic, ValueTask<TResult>> mimic, Func<<#
+        for (int i = 1; i <= argumentCount; i++) { #>T<#=i#>, <# } #>TResult> valueFunction)
+        where TMimic : class
+    {
+        return mimic.Returns((<#
+        for (int i = 1; i <= argumentCount; i++)
+        { #>T<#=i#> t<#=i#><#
+            if (i != argumentCount) { #>, <# }
+        } #>) => new ValueTask<TResult>(valueFunction(<#
+        for (int i = 1; i <= argumentCount; i++)
+        { #>t<#=i#><#
+            if (i != argumentCount) { #>, <# }
+        } #>)));
+    }
+
+    <# } #>#endregion
+}

--- a/src/Mimic/Mimic.csproj
+++ b/src/Mimic/Mimic.csproj
@@ -2,24 +2,36 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        
+
         <PackageId>Mimic</PackageId>
         <PackageTags>mimic;mock;mocking;fake;substitute;spy;tdd;aaa;test;testing;unit-test;unit-testing</PackageTags>
         <Description>Fast, friendly and familiar mocking library for modern .NET</Description>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Castle.Core" Version="5.1.1" />
-
-      <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" PrivateAssets="All" />
-      <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
+        <PackageReference Include="Castle.Core" Version="5.1.1" />
+        <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" PrivateAssets="All" />
+        <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
         <InternalsVisibleTo Include="Mimic.UnitTests" />
+    </ItemGroup>
+    
+    <!-- Extensions\ReturnsExtensions.tt -->
+    <ItemGroup>
+        <None Update="Extensions\ReturnsExtensions.tt">
+            <Generator>TextTemplatingFileGenerator</Generator>
+            <LastGenOutput>ReturnsExtensions.Generated.cs</LastGenOutput>
+        </None>
+        <Compile Update="Extensions\ReturnsExtensions.Generated.cs">
+            <AutoGen>True</AutoGen>
+            <DesignTime>True</DesignTime>
+            <DependentUpon>ReturnsExtensions.tt</DependentUpon>
+        </Compile>
     </ItemGroup>
 
 </Project>

--- a/src/Mimic/Mimic.csproj.DotSettings
+++ b/src/Mimic/Mimic.csproj.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:s="clr-namespace:System;assembly=mscorlib"
+                        xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=extensions/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Mimic/Setup/Fluent/IReturns`2.cs
+++ b/src/Mimic/Setup/Fluent/IReturns`2.cs
@@ -10,8 +10,6 @@ public interface IReturns<TMimic, in TResult> : IFluent
 {
     IReturnsResult<TMimic> Returns(TResult? value);
 
-    IReturnsResult<TMimic> Returns(Delegate valueFactory);
-
     IReturnsResult<TMimic> Returns(Func<TResult?> valueFunction);
 
     IReturnsResult<TMimic> Returns<T>(Func<T, TResult> valueFunction);

--- a/src/Mimic/Setup/Fluent/Implementations/NonVoidSetup`2.cs
+++ b/src/Mimic/Setup/Fluent/Implementations/NonVoidSetup`2.cs
@@ -138,12 +138,6 @@ internal sealed class NonVoidSetup<TMimic, TResult> : SetupBase, ISetup<TMimic, 
         return this;
     }
 
-    public IReturnsResult<TMimic> Returns(Delegate valueFactory)
-    {
-        Setup.SetReturnComputedValueBehaviour(valueFactory);
-        return this;
-    }
-
     public IReturnsResult<TMimic> Returns(Func<TResult?> valueFactory)
     {
         Setup.SetReturnComputedValueBehaviour(valueFactory);


### PR DESCRIPTION
Adds a set of new Extension Methods for `.Returns` that are specifically tailored for `Task<T>`/`ValueTask<T>`.

Using these extension methods means you can setup a return value without needing a `Task.FromResult(...)` keeping consuming code clean.