### PR TITLE
feat: Support for mimicking classes

### DIFF
--- a/src/Mimic.UnitTests/Core/Extensions/TypeExtensionsTests.cs
+++ b/src/Mimic.UnitTests/Core/Extensions/TypeExtensionsTests.cs
@@ -5,6 +5,16 @@ namespace Mimic.UnitTests.Core.Extensions;
 public class TypeExtensionsTests
 {
     [Theory]
+    [InlineData(typeof(IInterface), true)]
+    [InlineData(typeof(AbstractClass), true)]
+    [InlineData(typeof(RegularClass), true)]
+    [InlineData(typeof(SealedClass), false)]
+    public void CanBeMimicked_ReturnsExpectedResultForType(Type type, bool expectedResult)
+    {
+        type.CanBeMimicked().ShouldBe(expectedResult);
+    }
+
+    [Theory]
     [InlineData(typeof(bool), default(bool))]
     [InlineData(typeof(byte), default(byte))]
     [InlineData(typeof(sbyte), default(sbyte))]
@@ -154,4 +164,9 @@ public class TypeExtensionsTests
     private class A;
     private class B : A;
     private class C;
+
+    private interface IInterface;
+    private abstract class AbstractClass;
+    private class RegularClass;
+    private sealed class SealedClass;
 }

--- a/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests.cs
@@ -332,7 +332,8 @@ public class SequenceSetupTests
         return new MethodCallSetup(methodCallExpression, mimic, methodExpectation, null);
     }
 
-    private interface ISubject
+    // ReSharper disable once MemberCanBePrivate.Global
+    internal interface ISubject
     {
         public void MethodWithNoParameters();
         public void MethodWithParameters(int v1);

--- a/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests`1.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests`1.cs
@@ -571,7 +571,8 @@ public class SequenceSetupOfTResultTests
         return new MethodCallSetup(methodCallExpression, mimic, methodExpectation, null);
     }
 
-    private interface ISubject
+    // ReSharper disable once MemberCanBePrivate.Global
+    internal interface ISubject
     {
         public string MethodWithNoParameters();
         public string MethodWithParameters(int v1);

--- a/src/Mimic.UnitTests/Setup/Fluent/SetterSetupTests.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SetterSetupTests.cs
@@ -39,7 +39,7 @@ public class SetterSetupTests
 
     private static MethodCallSetup ToMethodCallSetup(Action<ISubject> setterExpression)
     {
-        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression);
+        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression, null);
 
         var mimic = new Mimic<ISubject>();
         var methodCallExpression = (MethodCallExpression)expression.Body;

--- a/src/Mimic.UnitTests/Setup/Fluent/SetupTests`1.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SetupTests`1.cs
@@ -557,7 +557,8 @@ public static partial class SetupTests
             return new MethodCallSetup(methodCallExpression, mimic, methodExpectation, null);
         }
 
-        private interface ISubject
+        // ReSharper disable once MemberCanBePrivate.Global
+        internal interface ISubject
         {
             public void MethodWithNoParameters();
             public void MethodWithParameters(int v1);

--- a/src/Mimic.UnitTests/Setup/Fluent/SetupTests`2.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SetupTests`2.cs
@@ -801,7 +801,8 @@ public static partial class SetupTests
             return new MethodCallSetup(methodCallExpression, mimic, methodExpectation, null);
         }
 
-        private interface ISubject
+        // ReSharper disable once MemberCanBePrivate.Global
+        internal interface ISubject
         {
             public string MethodWithNoParameters();
             public string MethodWithParameters(int v1);

--- a/src/Mimic.UnitTests/Setup/MethodCallSetupTests.cs
+++ b/src/Mimic.UnitTests/Setup/MethodCallSetupTests.cs
@@ -958,7 +958,8 @@ public class MethodCallSetupTests
         return (setup, mimic, methodCallExpression, methodExpectation);
     }
 
-    private interface ISubject
+    // ReSharper disable once MemberCanBePrivate.Global
+    internal interface ISubject
     {
         public void BasicVoidMethod(int iValue, string sValue, double dValue, List<bool> bValues);
 

--- a/src/Mimic/Core/Extensions/TypeExtensions.cs
+++ b/src/Mimic/Core/Extensions/TypeExtensions.cs
@@ -2,6 +2,8 @@
 
 internal static class TypeExtensions
 {
+    internal static bool CanBeMimicked(this Type type) => type is { IsInterface: true } or { IsClass: true, IsSealed: false };
+
     internal static object? GetDefaultValue(this Type type) => type.IsValueType ? Activator.CreateInstance(type) : null;
 
     internal static bool CompareWith(this Type[] types, Type[] otherTypes)

--- a/src/Mimic/Exceptions/MimicException.cs
+++ b/src/Mimic/Exceptions/MimicException.cs
@@ -25,6 +25,15 @@ public class MimicException : Exception
         info.AddValue(nameof(Identifier), Identifier);
     }
 
+    internal static MimicException TypeCannotBeMimicked(Type type, Exception? innerException = null) =>
+        new($"Type {TypeNameFormatter.GetFormattedName(type)} cannot be mimicked. It must be an interface or a non-sealed/non-static class.", innerException);
+
+    internal static MimicException NoConstructorWithMatchingArguments(Type type, Exception? innerException = null) =>
+        new ($"Unable to find a constructor in type {TypeNameFormatter.GetFormattedName(type)} matching given constructor arguments.", innerException);
+
+    internal static MimicException MethodNotAccessibleByProxyGenerator(MethodInfo method, string messageFromProxyGenerator) =>
+        new($"Method {method.Name} in type {TypeNameFormatter.GetFormattedName(method.DeclaringType!)} cannot be setup because it is not accessible by our proxy generator (Castle.DynamicProxy). Message returned from proxy generator: {messageFromProxyGenerator}");
+
     internal static MimicException UnmatchableArgumentMatcher(Expression argumentExpression, Type expectedType)
     {
         string formattedFromType = TypeNameFormatter.GetFormattedName(argumentExpression.Type);

--- a/src/Mimic/Exceptions/UnsupportedExpressionException.cs
+++ b/src/Mimic/Exceptions/UnsupportedExpressionException.cs
@@ -15,12 +15,14 @@ public sealed class UnsupportedExpressionException : MimicException
         : base($"Expression ({expression}) is currently unsupported. Reason: {reason}")
     {
         Expression = expression;
+        Reason = reason;
     }
 
     public UnsupportedExpressionException(Expression expression, string expressionRepresentation, UnsupportedReason reason = UnsupportedReason.Unknown)
         : base($"Expression ({expressionRepresentation}) is unsupported. Reason: {reason}")
     {
         Expression = expression;
+        Reason = reason;
     }
 
     public override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -35,6 +37,9 @@ public sealed class UnsupportedExpressionException : MimicException
         Unknown,
         MemberNotInterceptable,
         ExpressionThrewAnException,
-        UnableToDetermineArgumentMatchers
+        UnableToDetermineArgumentMatchers,
+        MemberIsStatic,
+        MemberIsExtension,
+        MemberIsNotOverridable
     }
 }

--- a/src/Mimic/Expressions/SetterExpressionConstructor.cs
+++ b/src/Mimic/Expressions/SetterExpressionConstructor.cs
@@ -4,11 +4,11 @@ namespace Mimic.Expressions;
 
 internal static class SetterExpressionConstructor
 {
-    internal static Expression<Action<T>> ConstructFromAction<T>(Action<T> action)
+    internal static Expression<Action<T>> ConstructFromAction<T>(Action<T> action, object[]? constructorArguments)
     {
         using var observer = ArgumentMatcherObserver.ActivateObserver();
 
-        var proxy = CreateProxy<T>(observer, out var interceptor);
+        var proxy = CreateProxy<T>(observer, constructorArguments, out var interceptor);
 
         Exception? exception = null;
         try
@@ -38,10 +38,10 @@ internal static class SetterExpressionConstructor
         throw new UnsupportedExpressionException(body, $"{actionParameterName} => {body}...", UnsupportedExpressionException.UnsupportedReason.ExpressionThrewAnException);
     }
 
-    private static T CreateProxy<T>(ArgumentMatcherObserver observer, out Interceptor interceptor)
+    private static T CreateProxy<T>(ArgumentMatcherObserver observer, object[]? constructorArguments, out Interceptor interceptor)
     {
         interceptor = new Interceptor(observer);
-        return (T)ProxyGenerator.Instance.GenerateProxy(typeof(T), Type.EmptyTypes, interceptor);
+        return (T)ProxyGenerator.Instance.GenerateProxy(typeof(T), Type.EmptyTypes, constructorArguments ?? Array.Empty<object>(), interceptor);
     }
 
     private static Expression[] GetArgumentExpressions(Expression body, Invocation invocation, IReadOnlyList<ArgumentMatcher> argumentMatchers)

--- a/src/Mimic/Mimic`1.Setup.cs
+++ b/src/Mimic/Mimic`1.Setup.cs
@@ -40,7 +40,7 @@ public partial class Mimic<T>
     {
         Guard.NotNull(setterExpression);
 
-        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression);
+        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression, ConstructorArguments);
         ValidateSetterExpression(expression);
 
         var setup = Setup(this, expression);
@@ -51,7 +51,7 @@ public partial class Mimic<T>
     {
         Guard.NotNull(setterExpression);
 
-        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression);
+        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression, ConstructorArguments);
         ValidateSetterExpression(expression);
 
         var setup = Setup(this, expression);

--- a/src/Mimic/Mimic`1.VerifyReceived.cs
+++ b/src/Mimic/Mimic`1.VerifyReceived.cs
@@ -147,7 +147,7 @@ public partial class Mimic<T>
     {
         Guard.NotNull(setterExpression);
 
-        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression);
+        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression, ConstructorArguments);
         if (expression.Body is not BinaryExpression { NodeType: ExpressionType.Assign, Left: MemberExpression or IndexExpression })
         {
             if (expression.Body.NodeType is not ExpressionType.Call)

--- a/src/Mimic/Setup/Fluent/ConditionalSetup`1.cs
+++ b/src/Mimic/Setup/Fluent/ConditionalSetup`1.cs
@@ -47,7 +47,7 @@ internal sealed class ConditionalSetup<TMimic> : IConditionalSetup<TMimic>
     {
         Guard.NotNull(setterExpression);
 
-        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression);
+        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression, _mimic.ConstructorArguments);
         Mimic<TMimic>.ValidateSetterExpression(expression);
 
         var setup = Mimic<TMimic>.Setup(_mimic, expression, _condition);
@@ -58,7 +58,7 @@ internal sealed class ConditionalSetup<TMimic> : IConditionalSetup<TMimic>
     {
         Guard.NotNull(setterExpression);
 
-        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression);
+        var expression = SetterExpressionConstructor.ConstructFromAction(setterExpression, _mimic.ConstructorArguments);
         Mimic<TMimic>.ValidateSetterExpression(expression);
 
         var setup = Mimic<TMimic>.Setup(_mimic, expression, _condition);


### PR DESCRIPTION
Adds support for mimicking classes along with the previously supported interfaces provided the class meets some criteria; non-static, non-sealed and accessible by the proxy generator.

Example usage (when class has a parameterless constructor):
```cs
var mimickedClass = new Mimic<ClassWithParameterlessConstructor>();
```

Example usage (when class needs constructor arguments):
```cs
var mimickedClass = new Mimic<ClassWithSpecificConstructor>
{
    ConstructorArguments = [1, "arg2", 3m, new object()]
};
```