### PR TITLE
feat: Support for `Proceed()`'ing to base implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ to change without warning between versions until the v1 release.
 ## What is Mimic
 
 **Mimic** is a friendly and familiar mocking library built for modern .NET built on top of the [Castle Project][castle]'s
-dynamic proxy generator. It's simple, intuitive and type-safe API for configuring mimic's of interfaces allows for both;
-Setup of return values for methods/properties and verifying if method calls have been received after the fact.
+dynamic proxy generator. It's simple, intuitive and type-safe API for configuring mimic's of interfaces/classes allows
+for both; Setup of return values for methods/properties and verifying if method calls have been received after the fact.
 
 ```csharp
 var mimic = new Mimic<ITypeToMimic>();
@@ -38,13 +38,13 @@ mimic.VerifyReceived(m => m.IsMimicEasyToUse("it's so intuitive"), CallCount.AtL
 ## Features
 
 - A friendly interface designed to ease adoption by users of other popular .NET mocking libraries
-- Support for generating mock objects of interfaces (**_Coming Soon_**: and overridable members in classes)
+- Support for generating mock objects of interfaces and overridable members in classes
 - Intuitive and type-safe expression based API for setups and verification of methods
 - Mimic is **strict by default**, meaning it throws for methods without a corresponding setup, but it's possible to
   disable the default behaviour by setting `Strict = false` on construction
 - Quick and easy stubbing of properties to store and retrieve values
 - Comprehensive set of behaviours for method setups such as; `Returns`, `Throws`, `Callback`, `When`, `Limit`,
-  `Expected` and `AsSequence`
+  `Expected`, `AsSequence` and `Proceed`
 - Verification of expected, setup and received calls including asserting no additional calls
 
 ## Roadmap
@@ -53,7 +53,6 @@ mimic.VerifyReceived(m => m.IsMimicEasyToUse("it's so intuitive"), CallCount.AtL
 Considering = ❓ | Planned = 📅 | In-Progress = 🚧
 ```
 
-- [🚧] Mimic of classes, specifically overridable members within classes, with support for calling base implementations
 - [📅] Implicit mimicking of nested setups (e.g. `m => m.MethodThatReturnsInterface().MethodOnThatInterface()`)
 - [📅] Delay behaviour (or Extension to `Returns`/`Throws`) for setups that allows for specific or random delays in
   execution time

--- a/src/Mimic.Sandbox/Program.cs
+++ b/src/Mimic.Sandbox/Program.cs
@@ -81,10 +81,33 @@ Console.WriteLine(outResult);
 
 mimic.VerifyExpectedReceived();
 
+ExampleUsingAnAbstractClass();
+
 static void SetupRef(Mimic<ITypeToMimic> mimic1)
 {
     string outValue = "OutValue?";
     mimic1.Setup(m => m.Ref(ref Arg.Ref<int>.Any, out outValue));
+}
+
+static void ExampleUsingAnAbstractClass()
+{
+    var mimic = new Mimic<AbstractClass>();
+
+    mimic.Setup(m => m.VirtualVoidMethod()).AsSequence()
+        .Next()
+        .Proceed()
+        .Next();
+
+    mimic.Setup(m => m.VirtualStringMethod())
+        .Proceed();
+
+    var mimickedObject = mimic.Object;
+
+    mimickedObject.VirtualVoidMethod();
+    mimickedObject.VirtualVoidMethod();
+    mimickedObject.VirtualVoidMethod();
+
+    Console.WriteLine($"Result from {nameof(AbstractClass.VirtualStringMethod)}: {mimickedObject.VirtualStringMethod()}");
 }
 
 public interface ITypeToMimic
@@ -102,4 +125,11 @@ public interface ITypeToMimic
     void Generic<T>();
 
     void Ref(ref int reference, out string outValue);
+}
+
+public abstract class AbstractClass
+{
+    public virtual void VirtualVoidMethod() => Console.WriteLine($"Hello from {nameof(VirtualVoidMethod)}");
+
+    public virtual string VirtualStringMethod() => "ValueFromBase";
 }

--- a/src/Mimic.UnitTests/Fixtures/InvocationFixture.cs
+++ b/src/Mimic.UnitTests/Fixtures/InvocationFixture.cs
@@ -7,6 +7,8 @@ internal sealed class InvocationFixture : Invocation
 {
     private static readonly MethodInfo DefaultMethod = typeof(InvocationFixture).GetMethod("ToString")!;
 
+    public bool ProceededToBase { get; private set; }
+
     public InvocationFixture(MethodInfo? method = null)
         : base(typeof(InvocationFixture), method ?? DefaultMethod, Array.Empty<object?>())
     {
@@ -21,6 +23,8 @@ internal sealed class InvocationFixture : Invocation
         : base(proxyType, method ?? DefaultMethod, arguments)
     {
     }
+
+    public override object Proceed() => ProceededToBase = true;
 
     public static InvocationFixture ForMethod<T>(string name, object?[]? arguments = null)
     {

--- a/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests.cs
@@ -312,6 +312,18 @@ public class SequenceSetupTests
     #endregion
 
     [Fact]
+    public void Proceed_ShouldCorrectlySetProceedBehaviour()
+    {
+        var methodCallSetup = ToMethodCallSetup<AbstractSubject>(m => m.VirtualMethod());
+        var setup = new SequenceSetup(methodCallSetup);
+
+        setup.Proceed().ShouldBeSameAs(setup);
+
+        (methodCallSetup.ConfiguredBehaviours.ReturnOrThrow as SequenceBehaviour).ShouldNotBeNull();
+        (methodCallSetup.ConfiguredBehaviours.ReturnOrThrow as SequenceBehaviour)!.Remaining.ShouldBe(1);
+    }
+
+    [Fact]
     public void Next_ShouldCorrectlySetSequenceBehaviour()
     {
         var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
@@ -323,9 +335,12 @@ public class SequenceSetupTests
         (methodCallSetup.ConfiguredBehaviours.ReturnOrThrow as SequenceBehaviour)!.Remaining.ShouldBe(1);
     }
 
-    private static MethodCallSetup ToMethodCallSetup(Expression<Action<ISubject>> expression)
+    private static MethodCallSetup ToMethodCallSetup(Expression<Action<ISubject>> expression) => ToMethodCallSetup<ISubject>(expression);
+
+    private static MethodCallSetup ToMethodCallSetup<T>(Expression<Action<T>> expression)
+        where T : class
     {
-        var mimic = new Mimic<ISubject>();
+        var mimic = new Mimic<T>();
         var methodCallExpression = (MethodCallExpression)expression.Body;
         var methodExpectation = new MethodExpectation(expression, methodCallExpression.Method, methodCallExpression.Arguments);
 
@@ -352,5 +367,13 @@ public class SequenceSetupTests
         public void MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14);
         public void MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14, int v15);
         public void MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14, int v15, int v16);
+    }
+
+    // ReSharper disable once MemberCanBePrivate.Global
+    internal abstract class AbstractSubject
+    {
+        public virtual void VirtualMethod()
+        {
+        }
     }
 }

--- a/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests`1.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests`1.cs
@@ -562,9 +562,24 @@ public class SequenceSetupOfTResultTests
 
     #endregion
 
-    private static MethodCallSetup ToMethodCallSetup(Expression<Action<ISubject>> expression)
+    [Fact]
+    public void Proceed_ShouldCorrectlySetProceedBehaviour()
     {
-        var mimic = new Mimic<ISubject>();
+        var methodCallSetup = ToMethodCallSetup<AbstractSubject>(m => m.VirtualMethod());
+        var setup = new SequenceSetup<string>(methodCallSetup);
+
+        setup.Proceed().ShouldBeSameAs(setup);
+
+        (methodCallSetup.ConfiguredBehaviours.ReturnOrThrow as SequenceBehaviour).ShouldNotBeNull();
+        (methodCallSetup.ConfiguredBehaviours.ReturnOrThrow as SequenceBehaviour)!.Remaining.ShouldBe(1);
+    }
+
+    private static MethodCallSetup ToMethodCallSetup(Expression<Action<ISubject>> expression) => ToMethodCallSetup<ISubject>(expression);
+
+    private static MethodCallSetup ToMethodCallSetup<T>(Expression<Action<T>> expression)
+        where T : class
+    {
+        var mimic = new Mimic<T>();
         var methodCallExpression = (MethodCallExpression)expression.Body;
         var methodExpectation = new MethodExpectation(expression, methodCallExpression.Method, methodCallExpression.Arguments);
 
@@ -591,5 +606,11 @@ public class SequenceSetupOfTResultTests
         public string MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14);
         public string MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14, int v15);
         public string MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14, int v15, int v16);
+    }
+
+    // ReSharper disable once MemberCanBePrivate.Global
+    internal abstract class AbstractSubject
+    {
+        public virtual string VirtualMethod() => default!;
     }
 }

--- a/src/Mimic.UnitTests/Setup/Fluent/SetupTests`1.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SetupTests`1.cs
@@ -536,6 +536,18 @@ public static partial class SetupTests
         }
 
         [Fact]
+        public void Proceed_ShouldReturnInitializedSequenceSetup()
+        {
+            var methodCallSetup = ToMethodCallSetup<AbstractSubject>(m => m.VirtualMethod());
+            var setup = new Setup<ISubject>(methodCallSetup);
+
+            setup.Proceed().ShouldBeSameAs(setup);
+
+            methodCallSetup.ConfiguredBehaviours.ReturnOrThrow.ShouldNotBeNull();
+            methodCallSetup.ConfiguredBehaviours.ReturnOrThrow.ShouldBeSameAs(ProceedBehaviour.Instance);
+        }
+
+        [Fact]
         public void AsSequence_ShouldReturnInitializedSequenceSetup()
         {
             var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
@@ -548,9 +560,12 @@ public static partial class SetupTests
             methodCallSetup.ConfiguredBehaviours.ReturnOrThrow.ShouldBeNull();
         }
 
-        private static MethodCallSetup ToMethodCallSetup(Expression<Action<ISubject>> expression)
+        private static MethodCallSetup ToMethodCallSetup(Expression<Action<ISubject>> expression) => ToMethodCallSetup<ISubject>(expression);
+
+        private static MethodCallSetup ToMethodCallSetup<T>(Expression<Action<T>> expression)
+            where T : class
         {
-            var mimic = new Mimic<ISubject>();
+            var mimic = new Mimic<T>();
             var methodCallExpression = (MethodCallExpression)expression.Body;
             var methodExpectation = new MethodExpectation(expression, methodCallExpression.Method, methodCallExpression.Arguments);
 
@@ -577,6 +592,14 @@ public static partial class SetupTests
             public void MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14);
             public void MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14, int v15);
             public void MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14, int v15, int v16);
+        }
+
+        // ReSharper disable once MemberCanBePrivate.Global
+        internal abstract class AbstractSubject
+        {
+            public virtual void VirtualMethod()
+            {
+            }
         }
     }
 }

--- a/src/Mimic.UnitTests/Setup/Fluent/SetupTests`2.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SetupTests`2.cs
@@ -780,6 +780,18 @@ public static partial class SetupTests
         #endregion
 
         [Fact]
+        public void Proceed_ShouldReturnInitializedSequenceSetup()
+        {
+            var methodCallSetup = ToMethodCallSetup<AbstractSubject>(m => m.VirtualMethod());
+            var setup = new Setup<ISubject, string>(methodCallSetup);
+
+            setup.Proceed().ShouldBeSameAs(setup);
+
+            methodCallSetup.ConfiguredBehaviours.ReturnOrThrow.ShouldNotBeNull();
+            methodCallSetup.ConfiguredBehaviours.ReturnOrThrow.ShouldBeSameAs(ProceedBehaviour.Instance);
+        }
+
+        [Fact]
         public void AsSequence_ShouldReturnInitializedSequenceSetup()
         {
             var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
@@ -792,9 +804,12 @@ public static partial class SetupTests
             methodCallSetup.ConfiguredBehaviours.ReturnOrThrow.ShouldBeNull();
         }
 
-        private static MethodCallSetup ToMethodCallSetup(Expression<Action<ISubject>> expression)
+        private static MethodCallSetup ToMethodCallSetup(Expression<Action<ISubject>> expression) => ToMethodCallSetup<ISubject>(expression);
+
+        private static MethodCallSetup ToMethodCallSetup<T>(Expression<Action<T>> expression)
+            where T : class
         {
-            var mimic = new Mimic<ISubject>();
+            var mimic = new Mimic<T>();
             var methodCallExpression = (MethodCallExpression)expression.Body;
             var methodExpectation = new MethodExpectation(expression, methodCallExpression.Method, methodCallExpression.Arguments);
 
@@ -821,6 +836,12 @@ public static partial class SetupTests
             public string MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14);
             public string MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14, int v15);
             public string MethodWithParameters(int v1, int v2, int v3, int v4, int v5, int v6, int v7, int v8, int v9, int v10, int v11, int v12, int v13, int v14, int v15, int v16);
+        }
+
+        // ReSharper disable once MemberCanBePrivate.Global
+        internal abstract class AbstractSubject
+        {
+            public virtual string VirtualMethod() => default!;
         }
     }
 }

--- a/src/Mimic/Fluent/ICallbackResult.cs
+++ b/src/Mimic/Fluent/ICallbackResult.cs
@@ -2,6 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ICallbackResult : IThrows, IThrowsResult, ILimitable, IExpected, IFluent
-{
-}
+public interface ICallbackResult : IThrows, IThrowsResult, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/ICallbackResult`1.cs
+++ b/src/Mimic/Fluent/ICallbackResult`1.cs
@@ -2,6 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ICallbackResult<in TResult> : IReturns<TResult>, IThrows, ILimitable, IExpected, IFluent
-{
-}
+public interface ICallbackResult<in TResult> : IReturns<TResult>, IThrows, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/IGetterCallbackResult`1.cs
+++ b/src/Mimic/Fluent/IGetterCallbackResult`1.cs
@@ -2,6 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IGetterCallbackResult<in TProperty> : IGetterReturns<TProperty>, IThrows, ILimitable, IExpected, IFluent
-{
-}
+public interface IGetterCallbackResult<in TProperty> : IGetterReturns<TProperty>, IThrows, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/IGetterSetup`2.cs
+++ b/src/Mimic/Fluent/IGetterSetup`2.cs
@@ -2,6 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IGetterSetup<TMimic, in TProperty> : IGetterCallback<TProperty>,  IGetterReturns<TProperty>, IThrows, ILimitable, IExpected, IFluent
-{
-}
+public interface IGetterSetup<TMimic, in TProperty> : IGetterCallback<TProperty>,  IGetterReturns<TProperty>, IThrows, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/IProceed.cs
+++ b/src/Mimic/Fluent/IProceed.cs
@@ -2,4 +2,7 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IThrowsResult : ILimitable, IExpected, IFluent;
+public interface IProceed : IFluent
+{
+    IProceedResult Proceed();
+}

--- a/src/Mimic/Fluent/IProceedResult.cs
+++ b/src/Mimic/Fluent/IProceedResult.cs
@@ -2,4 +2,4 @@ namespace Mimic;
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IReturns<in TResult> : IReturns<TResult, IReturnsResult>;
+public interface IProceedResult : IThrows, IThrowsResult, IFluent;

--- a/src/Mimic/Fluent/IReturnsResult.cs
+++ b/src/Mimic/Fluent/IReturnsResult.cs
@@ -2,6 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IReturnsResult : ICallback, ILimitable, IExpected, IFluent
-{
-}
+public interface IReturnsResult : ICallback, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/IReturns`2.cs
+++ b/src/Mimic/Fluent/IReturns`2.cs
@@ -40,4 +40,6 @@ public interface IReturns<in TResult, out TNext> : IFluent
     TNext Returns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> valueFunction);
 
     TNext Returns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> valueFunction);
+
+    TNext Proceed();
 }

--- a/src/Mimic/Fluent/ISequenceSetup.cs
+++ b/src/Mimic/Fluent/ISequenceSetup.cs
@@ -4,5 +4,7 @@
 [EditorBrowsable(EditorBrowsableState.Never)]
 public interface ISequenceSetup : IThrows<ISequenceSetup>, IExpected, IFluent
 {
+    ISequenceSetup Proceed();
+
     ISequenceSetup Next();
 }

--- a/src/Mimic/Fluent/ISequenceSetup`1.cs
+++ b/src/Mimic/Fluent/ISequenceSetup`1.cs
@@ -2,6 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ISequenceSetup<in TResult> : IReturns<TResult, ISequenceSetup<TResult>>, IThrows<ISequenceSetup<TResult>>, IExpected, IFluent
-{
-}
+public interface ISequenceSetup<in TResult> : IReturns<TResult, ISequenceSetup<TResult>>, IThrows<ISequenceSetup<TResult>>, IExpected, IFluent;

--- a/src/Mimic/Fluent/ISetterSetup`2.cs
+++ b/src/Mimic/Fluent/ISetterSetup`2.cs
@@ -3,6 +3,4 @@
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
 public interface ISetterSetup<TMimic, out TProperty> : ISetterCallback<TProperty>, ILimitable, IExpected, IFluent
-    where TMimic : class
-{
-}
+    where TMimic : class;

--- a/src/Mimic/Fluent/ISetup`1.cs
+++ b/src/Mimic/Fluent/ISetup`1.cs
@@ -2,7 +2,7 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ISetup<TMimic> : ICallback, IThrows, ILimitable, IExpected, IFluent
+public interface ISetup<TMimic> : ICallback, IProceed, IThrows, ILimitable, IExpected, IFluent
     where TMimic : class
 {
     ISequenceSetup AsSequence();

--- a/src/Mimic/Fluent/IThrows.cs
+++ b/src/Mimic/Fluent/IThrows.cs
@@ -2,6 +2,4 @@ namespace Mimic;
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IThrows : IThrows<IThrowsResult>
-{
-}
+public interface IThrows : IThrows<IThrowsResult>;

--- a/src/Mimic/Proxy/InterfaceProxyBase.cs
+++ b/src/Mimic/Proxy/InterfaceProxyBase.cs
@@ -31,5 +31,8 @@ internal abstract class InterfaceProxyBase
     }
 
     private sealed class Invocation(Type proxyType, MethodInfo method, object?[] arguments)
-        : Mimic.Proxy.Invocation(proxyType, method, arguments);
+        : Mimic.Proxy.Invocation(proxyType, method, arguments)
+    {
+        public override object Proceed() => throw new NotSupportedException();
+    }
 }

--- a/src/Mimic/Proxy/Invocation.cs
+++ b/src/Mimic/Proxy/Invocation.cs
@@ -34,6 +34,8 @@ internal abstract class Invocation : IInvocation
         Arguments = arguments;
     }
 
+    public abstract object? Proceed();
+
     public void MarkMatchedBy(SetupBase setup)
     {
         Guard.Assert(MatchedSetup is null);

--- a/src/Mimic/Proxy/ProxyGenerator.cs
+++ b/src/Mimic/Proxy/ProxyGenerator.cs
@@ -106,6 +106,14 @@ internal sealed class ProxyGenerator
             _underlyingInvocation = underlyingInvocation;
         }
 
+        public override object? Proceed()
+        {
+            Guard.NotNull(_underlyingInvocation);
+
+            _underlyingInvocation.Proceed();
+            return _underlyingInvocation.ReturnValue;
+        }
+
         public void Detatch()
         {
             _underlyingInvocation = null;

--- a/src/Mimic/Setup/Behaviours/ProceedBehaviour.cs
+++ b/src/Mimic/Setup/Behaviours/ProceedBehaviour.cs
@@ -1,0 +1,8 @@
+﻿namespace Mimic.Setup.Behaviours;
+
+internal sealed class ProceedBehaviour : Behaviour
+{
+    public static readonly ProceedBehaviour Instance = new();
+
+    internal override void Execute(Invocation invocation) => invocation.SetReturnValue(invocation.Proceed());
+}

--- a/src/Mimic/Setup/Fluent/SequenceSetupBase.cs
+++ b/src/Mimic/Setup/Fluent/SequenceSetupBase.cs
@@ -152,6 +152,12 @@ internal abstract class SequenceSetupBase<TNext> : IThrows<TNext>, IExpected
         return This;
     }
 
+    public TNext Proceed()
+    {
+        Setup.AddProceedBehaviour();
+        return This;
+    }
+
     public void Expected() => Setup.FlagAsExpected();
 
     public override string ToString() => Setup.Expression.ToString();

--- a/src/Mimic/Setup/Fluent/Setup`1.cs
+++ b/src/Mimic/Setup/Fluent/Setup`1.cs
@@ -1,10 +1,16 @@
 namespace Mimic.Setup.Fluent;
 
-internal class Setup<TMimic> : SetupBase, ISetup<TMimic>
+internal class Setup<TMimic> : SetupBase, ISetup<TMimic>, IProceedResult
     where TMimic : class
 {
     public Setup(MethodCallSetup setup) : base(setup)
     {
+    }
+
+    public IProceedResult Proceed()
+    {
+        Setup.SetProceedBehaviour();
+        return this;
     }
 
     public ISequenceSetup AsSequence() => new SequenceSetup(Setup);

--- a/src/Mimic/Setup/Fluent/Setup`2.cs
+++ b/src/Mimic/Setup/Fluent/Setup`2.cs
@@ -242,5 +242,11 @@ internal sealed class Setup<TMimic, TResult> : SetupBase, ISetup<TMimic, TResult
 
     #endregion
 
+    public IReturnsResult Proceed()
+    {
+        Setup.SetProceedBehaviour();
+        return this;
+    }
+
     public ISequenceSetup<TResult> AsSequence() => new SequenceSetup<TResult>(Setup);
 }

--- a/src/Mimic/Setup/MethodCallSetup.cs
+++ b/src/Mimic/Setup/MethodCallSetup.cs
@@ -84,6 +84,14 @@ internal sealed class MethodCallSetup : SetupBase
         _returnOrThrow = ThrowExceptionBehaviourFromExecptionFactory(exceptionFactory);
     }
 
+    public void SetProceedBehaviour()
+    {
+        Guard.Assert(MethodInfo.DeclaringType!.IsClass && !MethodInfo.IsAbstract, "Method must be non-abstract and declared in a class");
+        Guard.Assert(_returnOrThrow is null);
+
+        _returnOrThrow = ProceedBehaviour.Instance;
+    }
+
     public void SetCallbackBehaviour(Delegate callbackFunction)
     {
         Guard.NotNull(callbackFunction);
@@ -148,6 +156,13 @@ internal sealed class MethodCallSetup : SetupBase
         Guard.NotNull(exceptionFactory);
 
         AddBehaviour(ThrowExceptionBehaviourFromExecptionFactory(exceptionFactory));
+    }
+
+    public void AddProceedBehaviour()
+    {
+        Guard.Assert(MethodInfo.DeclaringType!.IsClass && !MethodInfo.IsAbstract, "Method must be non-abstract and declared in a class");
+
+        AddBehaviour(ProceedBehaviour.Instance);
     }
 
     public void AddNoOpBehaviour()


### PR DESCRIPTION
Adds support for proceeding to the base implementation of a non-abstract method in a mimicked class.

Example usage:
```cs
var mimickedClass = new Mimic<AbstractClass>();

mimickedClass.Setup(m => m.NonAbstractMethod())
    .Proceed();

mimickedClass.Setup(m => m.NonAbstractMethod())
    .Callback(() => Console.WriteLine("Still hit's callbacks!"))
    .Proceed();
```