### PR TITLE
feat: Support for setup of nested method calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ mimic.VerifyReceived(m => m.IsMimicEasyToUse("it's so intuitive"), CallCount.AtL
 - Mimic is **strict by default**, meaning it throws for methods without a corresponding setup, but it's possible to
   disable the default behaviour by setting `Strict = false` on construction
 - Quick and easy stubbing of properties to store and retrieve values
+- Implicit mocking of interfaces returned by mimicked methods allowing for easy setup of nested calls
 - Comprehensive set of behaviours for method setups such as; `Returns`, `Throws`, `Callback`, `When`, `Limit`,
   `Expected`, `AsSequence` and `Proceed`
 - Verification of expected, setup and received calls including asserting no additional calls
@@ -53,7 +54,6 @@ mimic.VerifyReceived(m => m.IsMimicEasyToUse("it's so intuitive"), CallCount.AtL
 Considering = ❓ | Planned = 📅 | In-Progress = 🚧
 ```
 
-- [📅] Implicit mimicking of nested setups (e.g. `m => m.MethodThatReturnsInterface().MethodOnThatInterface()`)
 - [📅] Delay behaviour (or Extension to `Returns`/`Throws`) for setups that allows for specific or random delays in
   execution time
 - [❓] Setup and Verification of Event's

--- a/src/Mimic.Sandbox/Program.cs
+++ b/src/Mimic.Sandbox/Program.cs
@@ -36,8 +36,16 @@ mimic.Setup(m => m.Generic<Generic.AnyType>())
 
 SetupRef(mimic);
 
+mimic.Setup(m => m.NestingTest().NestedMethod())
+    .Returns("Returned from the nested method call")
+    .Expected();
+
 var mimickedObject = mimic.Object;
 mimickedObject.VoidMethod();
+
+bool isMimickedNestedType = mimickedObject.NestingTest() is IMimicked<INestedType>;
+Console.WriteLine($"Is IMimicked<INestedType> {isMimickedNestedType}");
+Console.WriteLine(mimickedObject.NestingTest().NestedMethod());
 
 string result = await mimickedObject.StringMethod("other");
 Console.WriteLine(result);
@@ -125,6 +133,13 @@ public interface ITypeToMimic
     void Generic<T>();
 
     void Ref(ref int reference, out string outValue);
+
+    INestedType NestingTest();
+}
+
+public interface INestedType
+{
+    public string NestedMethod();
 }
 
 public abstract class AbstractClass

--- a/src/Mimic.UnitTests/Core/ImmutableStackTests.cs
+++ b/src/Mimic.UnitTests/Core/ImmutableStackTests.cs
@@ -1,0 +1,30 @@
+﻿
+using Mimic.Core;
+
+namespace Mimic.UnitTests.Core;
+
+public class ImmutableStackTests
+{
+    [Fact]
+    public void Constructor_ShouldSuccessfullyConstruct()
+    {
+        var immutableStack = new ImmutableStack<int>([]);
+        immutableStack.IsEmpty.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Constructor_WhenItemsIsNull_ShouldThrowAssertionException()
+    {
+        var ex = Should.Throw<Guard.AssertionException>(() => new ImmutableStack<int>(null!));
+        ex.Message.ShouldBe("items must not be null (Expression 'items')");
+    }
+
+    [Fact]
+    public void Pop_ShouldReturnTopItemAndRemainingItems()
+    {
+        var immutableStack = new ImmutableStack<int>([1, 2, 3]);
+
+        immutableStack.Pop(out var remainingItems).ShouldBe(1);
+        remainingItems.IsEmpty.ShouldBeFalse();
+    }
+}

--- a/src/Mimic.UnitTests/Setup/MethodExpectationTests.cs
+++ b/src/Mimic.UnitTests/Setup/MethodExpectationTests.cs
@@ -242,7 +242,72 @@ public class MethodExpectationTests
         expectation.MatchesInvocation(invocation).ShouldBeFalse();
     }
 
-    private static MethodExpectation ConstructMethodExpectation(Expression<Action<ISubject>> expression)
+    [Theory]
+    [AutoData]
+    public void Equals_WhenCalledWithMatchingObject_ShouldReturnTrue(int iValue)
+    {
+        var expectationOne = ConstructMethodExpectation(s => s.MethodWithArguments(iValue, Arg.Any<string>()));
+        var expectationTwo = ConstructMethodExpectation(s => s.MethodWithArguments(iValue, Arg.Any<string>()));
+
+        expectationOne.Equals(expectationTwo).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_WhenCalledWithWrongObjectType_ShouldReturnFalse()
+    {
+        var expectation = ConstructMethodExpectation(s => s.MethodWithArguments(Arg.Any<int>(), Arg.Any<string>()));
+
+        // ReSharper disable once SuspiciousTypeConversion.Global
+        expectation.Equals("obviously wrong type").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WhenCalledWithWrongExpectationType_ShouldReturnFalse()
+    {
+        var expectation = ConstructMethodExpectation(s => s.MethodWithArguments(Arg.Any<int>(), Arg.Any<string>()));
+        var allPropertiesStubSetupExpectation = new AllPropertiesStubSetup(new Mimic<ISubject>()).Expectation;
+
+        expectation.Equals(allPropertiesStubSetupExpectation).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WhenExpectationsHaveDifferentMethods_ShouldReturnFalse()
+    {
+        var expectationOne = ConstructMethodExpectation(s => s.MethodWithArguments(Arg.Any<int>(), Arg.Any<string>()));
+        var expectationTwo = ConstructMethodExpectation(s => s.MethodWithNoArguments());
+
+        expectationOne.Equals(expectationTwo).ShouldBeFalse();
+    }
+
+    [Theory]
+    [AutoData]
+    public void Equals_WhenExpectationsHaveDifferentArgumentValues_ShouldReturnFalse(int iValue)
+    {
+        var expectationOne = ConstructMethodExpectation(s => s.MethodWithArguments(Arg.Any<int>(), Arg.Any<string>()));
+        var expectationTwo = ConstructMethodExpectation(s => s.MethodWithArguments(iValue, Arg.Any<string>()));
+
+        expectationOne.Equals(expectationTwo).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_WhenExpectationsHaveSameMethods_ShouldReturnTrue()
+    {
+        var expectationOne = ConstructMethodExpectation(s => s.MethodWithArguments(Arg.Any<int>(), Arg.Any<string>()));
+        var expectationTwo = ConstructMethodExpectation(s => s.MethodWithArguments(Arg.Any<int>(), Arg.Any<string>()));
+
+        expectationOne.GetHashCode().ShouldBe(expectationTwo.GetHashCode());
+    }
+
+    [Fact]
+    public void GetHashCode_WhenExpectationsHaveDifferentMethods_ShouldReturnFalse()
+    {
+        var expectationOne = ConstructMethodExpectation(s => s.MethodWithArguments(Arg.Any<int>(), Arg.Any<string>()));
+        var expectationTwo = ConstructMethodExpectation(s => s.MethodWithNoArguments());
+
+        expectationOne.GetHashCode().ShouldNotBe(expectationTwo.GetHashCode());
+    }
+
+    internal static MethodExpectation ConstructMethodExpectation(Expression<Action<ISubject>> expression)
     {
         var methodCallExpression = (MethodCallExpression)expression.Body;
         return new MethodExpectation(expression, methodCallExpression.Method, methodCallExpression.Arguments);

--- a/src/Mimic.UnitTests/Setup/NestedSetupTests.cs
+++ b/src/Mimic.UnitTests/Setup/NestedSetupTests.cs
@@ -1,0 +1,74 @@
+﻿using System.Linq.Expressions;
+using Mimic.Setup;
+
+namespace Mimic.UnitTests.Setup;
+
+public class NestedSetupTests
+{
+    [Fact]
+    public void Constructor_ShouldSuccessfullyConstruct()
+    {
+        var mimic = new Mimic<ISubject>();
+        Expression<Action<ISubject>> expression = m => m.GetNested();
+        var methodCallExpression = (MethodCallExpression)expression.Body;
+        var methodExpectation = new MethodExpectation(expression, methodCallExpression.Method, methodCallExpression.Arguments);
+
+        var nestedMimic = new Mimic<INestedSubject>();
+        var setup = new NestedSetup(methodCallExpression, mimic, methodExpectation, nestedMimic.Object);
+
+        setup.OriginalExpression.ShouldBeSameAs(methodCallExpression);
+        setup.Mimic.ShouldBeSameAs(mimic);
+        setup.Expectation.ShouldBeSameAs(methodExpectation);
+        setup.Expression.ShouldBeSameAs(methodExpectation.Expression);
+        setup.Matched.ShouldBeFalse();
+        setup.Overridden.ShouldBeFalse();
+        setup.Expected.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Execute_ShouldCorrectlySetReturnValueOfInvocation()
+    {
+        var mimic = new Mimic<ISubject>();
+        Expression<Action<ISubject>> expression = m => m.GetNested();
+        var methodCallExpression = (MethodCallExpression)expression.Body;
+        var methodExpectation = new MethodExpectation(expression, methodCallExpression.Method, methodCallExpression.Arguments);
+
+        var nestedMimic = new Mimic<INestedSubject>();
+        var setup = new NestedSetup(methodCallExpression, mimic, methodExpectation, nestedMimic.Object);
+
+        var invocation = InvocationFixture.ForMethod<ISubject>(nameof(ISubject.GetNested));
+        setup.Execute(invocation);
+
+        invocation.ReturnValue.ShouldBeSameAs(nestedMimic.Object);
+    }
+
+    [Fact]
+    public void GetNested_WhenTheReturnValueIsMimicked_ShouldReturnTheMimicObject()
+    {
+        var mimic = new Mimic<ISubject>();
+        Expression<Action<ISubject>> expression = m => m.GetNested();
+        var methodCallExpression = (MethodCallExpression)expression.Body;
+        var methodExpectation = new MethodExpectation(expression, methodCallExpression.Method, methodCallExpression.Arguments);
+
+        var nestedMimic = new Mimic<INestedSubject>();
+        var setup = new NestedSetup(methodCallExpression, mimic, methodExpectation, nestedMimic.Object);
+
+        var nestedMimics = setup.GetNested();
+
+        nestedMimics.ShouldNotBeNull();
+        nestedMimics.ShouldNotBeEmpty();
+        nestedMimics[0].ShouldBeSameAs(nestedMimic);
+    }
+
+    // ReSharper disable once MemberCanBePrivate.Global
+    internal interface ISubject
+    {
+        public INestedSubject GetNested();
+    }
+
+    // ReSharper disable once MemberCanBePrivate.Global
+    internal interface INestedSubject
+    {
+        public void NestedMethod();
+    }
+}

--- a/src/Mimic.UnitTests/Setup/PropertyStubSetupTests.cs
+++ b/src/Mimic.UnitTests/Setup/PropertyStubSetupTests.cs
@@ -160,7 +160,40 @@ public class PropertyStubSetupTests
         property.CanWriteProperty(out var setter, out _);
 
         var setup = new PropertyStubSetup(_mimic, expression, getter!, setter!, null);
-        Should.NotThrow(() => setup.VerifyMatched());
+        Should.NotThrow(() => setup.VerifyMatched(_ => true, []));
+    }
+
+    [Fact]
+    public void GetNested_WhenCurrentValueIsNotMimicked_ShouldReturnAnEmptyList()
+    {
+        LambdaExpression expression = (ISubject subject) => subject.StringProperty;
+        var property = typeof(ISubject).GetProperty(nameof(ISubject.StringProperty))!;
+        property.CanReadProperty(out var getter, out _);
+        property.CanWriteProperty(out var setter, out _);
+
+        var setup = new PropertyStubSetup(_mimic, expression, getter!, setter!, string.Empty);
+
+        var nestedMimics = setup.GetNested();
+        nestedMimics.ShouldNotBeNull();
+        nestedMimics.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GetNested_WhenCurrentValueIsMimicked_ShouldReturnListContainingOnlyTheMimicObject()
+    {
+        LambdaExpression expression = (ISubject subject) => subject.NestedSubject;
+        var property = typeof(ISubject).GetProperty(nameof(ISubject.NestedSubject))!;
+        property.CanReadProperty(out var getter, out _);
+        property.CanWriteProperty(out var setter, out _);
+
+        var nestedMimic = new Mimic<INestedSubject>();
+        var setup = new PropertyStubSetup(_mimic, expression, getter!, setter!, nestedMimic.Object);
+
+        var nestedMimics = setup.GetNested();
+        nestedMimics.ShouldNotBeNull();
+        nestedMimics.ShouldNotBeEmpty();
+        nestedMimics.Count.ShouldBe(1);
+        nestedMimics[0].ShouldBeSameAs(nestedMimic);
     }
 
     [Fact]
@@ -175,6 +208,79 @@ public class PropertyStubSetupTests
         setup.ToString().ShouldBe("PropertyStubSetupTests.ISubject subject => subject.StringProperty");
     }
 
+    [Fact]
+    public void Equals_WhenCalledWithMatchingObject_ShouldReturnTrue()
+    {
+        var stringProperty = typeof(ISubject).GetProperty(nameof(ISubject.StringProperty))!;
+        stringProperty.CanReadProperty(out var stringGetter, out _);
+        stringProperty.CanWriteProperty(out var stringSetter, out _);
+
+        var expectationOne = new PropertyStubSetup(_mimic, (ISubject subject) => subject.StringProperty, stringGetter!, stringSetter!, null).Expectation;
+        var expectationTwo = new PropertyStubSetup(_mimic, (ISubject subject) => subject.StringProperty, stringGetter!, stringSetter!, null).Expectation;
+
+        expectationOne.Equals(expectationTwo).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Equals_WhenCalledWithWrongObjectType_ShouldReturnFalse()
+    {
+        var stringProperty = typeof(ISubject).GetProperty(nameof(ISubject.StringProperty))!;
+        stringProperty.CanReadProperty(out var stringGetter, out _);
+        stringProperty.CanWriteProperty(out var stringSetter, out _);
+
+        var expectation = new PropertyStubSetup(_mimic, (ISubject subject) => subject.StringProperty, stringGetter!, stringSetter!, null).Expectation;
+
+        // ReSharper disable once SuspiciousTypeConversion.Global
+        expectation.Equals("obviously wrong type").ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WhenCalledWithWrongExpectationType_ShouldReturnFalse()
+    {
+        var stringProperty = typeof(ISubject).GetProperty(nameof(ISubject.StringProperty))!;
+        stringProperty.CanReadProperty(out var stringGetter, out _);
+        stringProperty.CanWriteProperty(out var stringSetter, out _);
+
+        var propertyStubSetupExpectation = new PropertyStubSetup(_mimic, (ISubject subject) => subject.StringProperty, stringGetter!, stringSetter!, null).Expectation;
+        var methodExpectation = MethodExpectationTests.ConstructMethodExpectation(m => m.MethodWithNoArguments());
+
+        propertyStubSetupExpectation.Equals(methodExpectation).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Equals_WhenExpectationIsForDifferentProperty_ShouldReturnTrue()
+    {
+        var stringProperty = typeof(ISubject).GetProperty(nameof(ISubject.StringProperty))!;
+        stringProperty.CanReadProperty(out var stringGetter, out _);
+        stringProperty.CanWriteProperty(out var stringSetter, out _);
+
+        var doubleProperty = typeof(ISubject).GetProperty(nameof(ISubject.DoubleProperty))!;
+        doubleProperty.CanReadProperty(out var doubleGetter, out _);
+        doubleProperty.CanWriteProperty(out var doubleSetter, out _);
+
+        var expectationOne = new PropertyStubSetup(_mimic, (ISubject subject) => subject.StringProperty, stringGetter!, stringSetter!, null).Expectation;
+        var expectationTwo = new PropertyStubSetup(_mimic, (ISubject subject) => subject.DoubleProperty, doubleGetter!, doubleSetter!, null).Expectation;
+
+        expectationOne.Equals(expectationTwo).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_ShouldAlwaysReturnMatchingValues()
+    {
+        var stringProperty = typeof(ISubject).GetProperty(nameof(ISubject.StringProperty))!;
+        stringProperty.CanReadProperty(out var stringGetter, out _);
+        stringProperty.CanWriteProperty(out var stringSetter, out _);
+
+        var doubleProperty = typeof(ISubject).GetProperty(nameof(ISubject.DoubleProperty))!;
+        doubleProperty.CanReadProperty(out var doubleGetter, out _);
+        doubleProperty.CanWriteProperty(out var doubleSetter, out _);
+
+        var expectationOne = new PropertyStubSetup(_mimic, (ISubject subject) => subject.StringProperty, stringGetter!, stringSetter!, null).Expectation;
+        var expectationTwo = new PropertyStubSetup(_mimic, (ISubject subject) => subject.DoubleProperty, doubleGetter!, doubleSetter!, null).Expectation;
+
+        expectationOne.GetHashCode().ShouldBe(expectationTwo.GetHashCode());
+    }
+
     private interface ISubject
     {
         public double DoubleProperty { get; set; }
@@ -182,5 +288,10 @@ public class PropertyStubSetupTests
         public string StringProperty { get; set; }
 
         public int IntMethod();
+
+        public INestedSubject NestedSubject { get; set; }
     }
+
+    // ReSharper disable once MemberCanBePrivate.Global
+    internal interface INestedSubject;
 }

--- a/src/Mimic.UnitTests/Setup/SetupCollectionTests.cs
+++ b/src/Mimic.UnitTests/Setup/SetupCollectionTests.cs
@@ -1,0 +1,161 @@
+﻿using System.Collections;
+using Mimic.Setup;
+
+namespace Mimic.UnitTests.Setup;
+
+public class SetupCollectionTests
+{
+    [Fact]
+    public void Constructor_ShouldSuccessfullyConstruct()
+    {
+        var setupCollection = new SetupCollection();
+
+        setupCollection.Count.ShouldBe(0);
+
+        // ReSharper disable once GenericEnumeratorNotDisposed
+        var enumerator = (setupCollection as IEnumerable).GetEnumerator();
+        enumerator.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Add_WhenNoExistingMatchingExpectation_ShouldAddSetupToCollection()
+    {
+        var setupCollection = new SetupCollection();
+        var (setup, _, _, _) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicVoidMethod(default, default!, default, default!));
+
+        setupCollection.Add(setup);
+
+        setupCollection.Count.ShouldBe(1);
+        setupCollection[0].ShouldBeSameAs(setup);
+    }
+
+    [Fact]
+    public void Add_WhenExistingMatchingExpectation_ShouldAddSetupToCollectionAndMarkExistingAsOverridden()
+    {
+        var setupCollection = new SetupCollection();
+
+        var (originalSetup, _, _, _) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicVoidMethod(default, default!, default, default!));
+
+        var (newSetup, _, _, _) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicVoidMethod(default, default!, default, default!));
+
+        setupCollection.Add(originalSetup);
+        setupCollection.Add(newSetup);
+
+        setupCollection.Count.ShouldBe(2);
+        setupCollection[0].ShouldBeSameAs(originalSetup);
+        setupCollection[1].ShouldBeSameAs(newSetup);
+
+        originalSetup.Overridden.ShouldBeTrue();
+        newSetup.Overridden.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Add_WhenExistingMatchingExpectations_ShouldAddSetupToCollectionAndMarkAllExistingAsOverridden()
+    {
+        var setupCollection = new SetupCollection();
+
+        var (originalSetup, _, _, _) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicVoidMethod(default, default!, default, default!));
+
+        var (intermediateSetup, _, _, _) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicVoidMethod(default, default!, default, default!));
+
+        var (newSetup, _, _, _) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicVoidMethod(default, default!, default, default!));
+
+        setupCollection.Add(originalSetup);
+        setupCollection.Add(intermediateSetup);
+        setupCollection.Add(newSetup);
+
+        setupCollection.Count.ShouldBe(3);
+        setupCollection[0].ShouldBeSameAs(originalSetup);
+        setupCollection[1].ShouldBeSameAs(intermediateSetup);
+        setupCollection[2].ShouldBeSameAs(newSetup);
+
+        originalSetup.Overridden.ShouldBeTrue();
+        intermediateSetup.Overridden.ShouldBeTrue();
+        newSetup.Overridden.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void FindAll_WhenNoSetups_ShouldReturnAnEmptyList()
+    {
+        var setupCollection = new SetupCollection();
+
+        var results = setupCollection.FindAll(_ => true);
+        results.ShouldNotBeNull();
+        results.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void FindAll_WhenContainsSetups_ShouldReturnAllMatchingNonOverridenSetups()
+    {
+        var (overridenSetup, _, _, _) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicVoidMethod(default, default!, default, default!));
+
+        var (matchingSetup, _, _, expectation) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicVoidMethod(default, default!, default, default!));
+
+        var (nonMatchingSetup, _, _, _) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicNonVoidMethod(default, default!, default, default!));
+
+        SetupCollection setupCollection = [overridenSetup, matchingSetup, nonMatchingSetup];
+
+        var results = setupCollection.FindAll(s => s.Expectation.Equals(expectation));
+        results.ShouldNotBeNull();
+        results.ShouldNotBeEmpty();
+        results.Count.ShouldBe(1);
+        results[0].ShouldBeSameAs(matchingSetup);
+    }
+
+    [Fact]
+    public void FindLast_WhenNoSetups_ShouldReturnNull()
+    {
+        var setupCollection = new SetupCollection();
+
+        setupCollection.FindLast(_ => true).ShouldBeNull();
+    }
+
+    [Fact]
+    public void FindLast_WhenNoMatchingSetup_ShouldReturnNull()
+    {
+        var (nonMatchingSetup, _, _, _) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicNonVoidMethod(default, default!, default, default!));
+
+        SetupCollection setupCollection = [nonMatchingSetup];
+
+        setupCollection.FindLast(_ => false).ShouldBeNull();
+    }
+
+    [Fact]
+    public void FindLast_WhenMatchingSetup_ShouldReturnNull()
+    {
+        var (matchingSetup, _, _, expectation) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicNonVoidMethod(default, default!, default, default!));
+
+        SetupCollection setupCollection = [matchingSetup];
+
+        var result = setupCollection.FindLast(s => s.Expectation.Equals(expectation));
+        result.ShouldNotBeNull();
+        result.ShouldBeSameAs(matchingSetup);
+    }
+
+    [Fact]
+    public void FindLast_WhenOverridenMatchingSetup_ShouldReturnNull()
+    {
+        var (overridenMatchingSetup, _, _, _) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicNonVoidMethod(default, default!, default, default!));
+
+        var (matchingSetup, _, _, expectation) = MethodCallSetupTests.ConstructMethodCallSetup(m =>
+            m.BasicNonVoidMethod(default, default!, default, default!));
+
+        SetupCollection setupCollection = [overridenMatchingSetup, matchingSetup];
+
+        var result = setupCollection.FindLast(s => s.Expectation.Equals(expectation));
+        result.ShouldNotBeNull();
+        result.ShouldBeSameAs(matchingSetup);
+    }
+}

--- a/src/Mimic/Core/ImmutableStack`1.cs
+++ b/src/Mimic/Core/ImmutableStack`1.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Immutable;
+
+namespace Mimic.Core;
+
+internal readonly struct ImmutableStack<T>
+{
+    private readonly ImmutableArray<T> _items;
+    private readonly int _index;
+
+    public bool IsEmpty => _index == _items.Length;
+
+    public ImmutableStack(IEnumerable<T> items)
+    {
+        Guard.NotNull(items);
+
+        _items = items.ToImmutableArray();
+        _index = 0;
+    }
+
+    private ImmutableStack(ImmutableArray<T> items, int index)
+    {
+        Guard.NotNull(items);
+        Guard.Assert(0 <= _index && _index <= items.Length);
+
+        _items = items;
+        _index = index;
+    }
+
+    public T Pop(out ImmutableStack<T> remainingItems)
+    {
+        Guard.Assert(_index < _items.Length);
+
+        remainingItems = new ImmutableStack<T>(_items, _index + 1);
+        return _items[_index];
+    }
+}

--- a/src/Mimic/Exceptions/MimicException.cs
+++ b/src/Mimic/Exceptions/MimicException.cs
@@ -130,9 +130,6 @@ public class MimicException : Exception
     internal static MimicException MethodIsNotOverridable(Expression expression) =>
         new(Reason.UnsupportedExpression, Strings.FormatMethodIsNotOverridable(expression));
 
-    internal static MimicException NestedMethodCallIsNotAllowed(Expression expression) =>
-        new(Reason.UnsupportedExpression, Strings.FormatNestedMethodCallIsNotAllowed(expression));
-
     internal static MimicException UnsupportedExpressionType(Expression expression) =>
         new(Reason.UnsupportedExpression, Strings.FormatUnsupportedExpressionType(expression));
 

--- a/src/Mimic/Expressions/ExpressionSplitter.cs
+++ b/src/Mimic/Expressions/ExpressionSplitter.cs
@@ -19,10 +19,10 @@ internal static class ExpressionSplitter
             parts.Push(part);
         }
 
-        if (parts.Count is 1 && remainder is ParameterExpression)
+        if (parts.Count > 0 && remainder is ParameterExpression)
             return parts;
 
-        throw MimicException.NestedMethodCallIsNotAllowed(expression);
+        throw MimicException.UnsupportedExpressionType(expression);
     }
 
     private static bool CanSplitExpression(Expression expression)

--- a/src/Mimic/IMimic.cs
+++ b/src/Mimic/IMimic.cs
@@ -1,6 +1,16 @@
+using Mimic.Setup;
+
 namespace Mimic;
 
 internal interface IMimic
 {
     bool Strict { get; }
+
+    object Object { get; }
+
+    SetupCollection Setups { get; }
+
+    IReadOnlyList<Invocation> Invocations { get; }
+
+    void VerifyReceived(Predicate<SetupBase> predicate, HashSet<IMimic> verified);
 }

--- a/src/Mimic/IMimicked.cs
+++ b/src/Mimic/IMimicked.cs
@@ -1,9 +1,6 @@
-﻿namespace Mimic;
+namespace Mimic;
 
-[PublicAPI]
-[EditorBrowsable(EditorBrowsableState.Never)]
-public interface IMimicked<T>
-    where T : class
+internal interface IMimicked
 {
-    Mimic<T> Mimic { get; }
+    IMimic Mimic { get; }
 }

--- a/src/Mimic/IMimicked`1.cs
+++ b/src/Mimic/IMimicked`1.cs
@@ -1,0 +1,9 @@
+﻿namespace Mimic;
+
+[PublicAPI]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface IMimicked<T>
+    where T : class
+{
+    Mimic<T> Mimic { get; }
+}

--- a/src/Mimic/Mimic`1.Interceptor.cs
+++ b/src/Mimic/Mimic`1.Interceptor.cs
@@ -41,7 +41,8 @@ public partial class Mimic<T>
 
     private static class WellKnownMethods
     {
-        private static readonly MethodInfo MimickedMimicPropertyGetter = typeof(IMimicked<T>).GetProperty(nameof(IMimicked<T>.Mimic))!.GetMethod!;
+        private static readonly MethodInfo MimickedMimicPropertyGetter = typeof(IMimicked).GetProperty(nameof(IMimicked.Mimic))!.GetMethod!;
+        private static readonly MethodInfo MimickedOfTMimicPropertyGetter = typeof(IMimicked<T>).GetProperty(nameof(IMimicked<T>.Mimic))!.GetMethod!;
         private static readonly MethodInfo ObjectToStringMethod = typeof(object).GetMethod(nameof(ToString), BindingFlags.Public | BindingFlags.Instance)!;
         private static readonly MethodInfo ObjectEqualsMethod = typeof(object).GetMethod(nameof(Equals), BindingFlags.Public | BindingFlags.Instance)!;
         private static readonly MethodInfo ObjectGetHashCodeMethod = typeof(object).GetMethod(nameof(GetHashCode), BindingFlags.Public | BindingFlags.Instance)!;
@@ -49,12 +50,22 @@ public partial class Mimic<T>
         public static readonly Dictionary<MethodInfo, Func<Invocation, Mimic<T>, bool>> Handlers = new()
         {
             [MimickedMimicPropertyGetter] = HandleMimickedMimicPropertyGetter,
+            [MimickedOfTMimicPropertyGetter] = HandleMimickedOfTMimicPropertyGetter,
             [ObjectToStringMethod] = HandleObjectToStringMethod,
             [ObjectEqualsMethod] = HandleObjectEqualsMethod,
             [ObjectGetHashCodeMethod] = HandleObjectGetHashCodeMethod
         };
 
         private static bool HandleMimickedMimicPropertyGetter(Invocation invocation, Mimic<T> mimic)
+        {
+            if (!typeof(IMimicked).IsAssignableFrom(invocation.Method.DeclaringType))
+                return false;
+
+            invocation.SetReturnValue(mimic);
+            return true;
+        }
+
+        private static bool HandleMimickedOfTMimicPropertyGetter(Invocation invocation, Mimic<T> mimic)
         {
             if (!typeof(IMimicked<T>).IsAssignableFrom(invocation.Method.DeclaringType))
                 return false;

--- a/src/Mimic/Mimic`1.cs
+++ b/src/Mimic/Mimic`1.cs
@@ -1,4 +1,6 @@
-﻿using Mimic.Setup.Fluent;
+﻿using Mimic.Setup;
+using Mimic.Setup.Fluent;
+using SetupBase = Mimic.Setup.SetupBase;
 
 namespace Mimic;
 
@@ -47,6 +49,8 @@ public sealed partial class Mimic<T> : IMimic
         Name = $"Mimic<{TypeNameFormatter.GetFormattedName(typeof(T))}>:{instanceNumber}";
     }
 
+    public Mimic(bool strict) : this() => Strict = strict;
+
     public static Mimic<T> FromObject(T objectInstance)
     {
         if (objectInstance is not IMimicked<T> mimicked)
@@ -61,10 +65,22 @@ public sealed partial class Mimic<T> : IMimic
     {
         return _object ??= (T)ProxyGenerator.Instance.GenerateProxy(
             typeof(T),
-            [typeof(IMimicked<T>)],
+            [typeof(IMimicked), typeof(IMimicked<T>)],
             _constructorArguments ?? Array.Empty<object>(),
             this);
     }
 
     public override string ToString() => Name;
+
+    #region IMimic
+
+    object IMimic.Object => Object;
+
+    SetupCollection IMimic.Setups => _setups;
+
+    IReadOnlyList<Invocation> IMimic.Invocations => Invocations;
+
+    void IMimic.VerifyReceived(Predicate<SetupBase> predicate, HashSet<IMimic> verified) => VerifyReceived(predicate, verified);
+
+    #endregion
 }

--- a/src/Mimic/Resources/Strings.resx
+++ b/src/Mimic/Resources/Strings.resx
@@ -69,9 +69,6 @@
     <data name="MethodIsNotOverridable" xml:space="preserve">
         <value>Expression ({0}) is unsupported as the specified method is not overridable. This could be due to it being; non-virtual, final or private.</value>
     </data>
-    <data name="NestedMethodCallIsNotAllowed" xml:space="preserve">
-        <value>Expression ({0}) is unsupported as it contains a nested method call (e.g. MethodOne().MethodTwo()) which is not currently supported.</value>
-    </data>
     <data name="UnsupportedExpressionType" xml:space="preserve">
         <value>Expression ({0}) contains an unsupported/unexpected expression type.</value>
     </data>

--- a/src/Mimic/Setup/AllPropertiesStubSetup.cs
+++ b/src/Mimic/Setup/AllPropertiesStubSetup.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using Mimic.Expressions;
 using Expr = System.Linq.Expressions.Expression;
 
 namespace Mimic.Setup;
@@ -32,10 +33,12 @@ internal sealed class AllPropertiesStubSetup : SetupBase
         }
     }
 
-    internal override void VerifyMatched()
+    internal override void VerifyMatched(Predicate<SetupBase> predicate, HashSet<IMimic> verified)
     {
         // intentionally empty
     }
+
+    internal override IReadOnlyList<IMimic> GetNested() => _currentValues.Values.OfType<IMimicked>().Select(m => m.Mimic).ToList();
 
     private sealed class AllPropertiesStubExpectation : IExpectation
     {
@@ -60,5 +63,12 @@ internal sealed class AllPropertiesStubSetup : SetupBase
 
             return (method.IsGetter() && parameterCount == 0) || (method.IsSetter() && parameterCount == 1);
         }
+
+        public override bool Equals(object? obj) => obj is AllPropertiesStubExpectation other &&  Equals(other);
+
+        public bool Equals(IExpectation? obj) =>
+            obj is AllPropertiesStubExpectation other && ExpressionEqualityComparer.Default.Equals(Expression, other.Expression);
+
+        public override int GetHashCode() => typeof(AllPropertiesStubExpectation).GetHashCode();
     }
 }

--- a/src/Mimic/Setup/Behaviours/ReturnValueBehaviour.cs
+++ b/src/Mimic/Setup/Behaviours/ReturnValueBehaviour.cs
@@ -2,9 +2,9 @@ namespace Mimic.Setup.Behaviours;
 
 internal sealed class ReturnValueBehaviour : Behaviour
 {
-    private readonly object? _value;
+    internal object? Value { get; }
 
-    public ReturnValueBehaviour(object? value) => _value = value;
+    public ReturnValueBehaviour(object? value) => Value = value;
 
-    internal override void Execute(Invocation invocation) => invocation.SetReturnValue(_value);
+    internal override void Execute(Invocation invocation) => invocation.SetReturnValue(Value);
 }

--- a/src/Mimic/Setup/IExpectation.cs
+++ b/src/Mimic/Setup/IExpectation.cs
@@ -1,6 +1,6 @@
 namespace Mimic.Setup;
 
-internal interface IExpectation
+internal interface IExpectation : IEquatable<IExpectation>
 {
     LambdaExpression Expression { get; }
 

--- a/src/Mimic/Setup/MethodCallSetup.cs
+++ b/src/Mimic/Setup/MethodCallSetup.cs
@@ -183,13 +183,16 @@ internal sealed class MethodCallSetup : SetupBase
 
     #endregion
 
-    internal override void VerifyMatched()
+    internal override void VerifyMatched(Predicate<SetupBase> predicate, HashSet<IMimic> verified)
     {
-        base.VerifyMatched();
+        base.VerifyMatched(predicate, verified);
 
         if (_returnOrThrow is SequenceBehaviour { Remaining: >0 } sequenceBehaviour)
             throw MimicException.ExpectedSequenceSetupNotMatched(this, sequenceBehaviour.Remaining);
     }
+
+    internal override IReadOnlyList<IMimic> GetNested() =>
+        ((_returnOrThrow as ReturnValueBehaviour)?.Value as IMimicked)?.Mimic is { } mimic ? [mimic] : [];
 
     internal void StrictThrowOrReturnDefault(Invocation invocation)
     {

--- a/src/Mimic/Setup/NestedSetup.cs
+++ b/src/Mimic/Setup/NestedSetup.cs
@@ -1,0 +1,19 @@
+﻿namespace Mimic.Setup;
+
+internal sealed class NestedSetup : SetupBase
+{
+    private readonly object _returnValue;
+
+    public NestedSetup(Expression? originalExpression, IMimic mimic, IExpectation expectation, object returnValue)
+        : base(originalExpression, mimic, expectation)
+    {
+        Guard.Assert(returnValue is IMimicked);
+        _returnValue = returnValue;
+
+        FlagAsExpected();
+    }
+
+    protected override void ExecuteCore(Invocation invocation) => invocation.SetReturnValue(_returnValue);
+
+    internal override IReadOnlyList<IMimic> GetNested() => _returnValue is IMimicked mimicked ? [mimicked.Mimic] : [];
+}

--- a/src/Mimic/Setup/PropertyStubSetup.cs
+++ b/src/Mimic/Setup/PropertyStubSetup.cs
@@ -1,3 +1,5 @@
+using Mimic.Expressions;
+
 namespace Mimic.Setup;
 
 internal sealed class PropertyStubSetup : SetupBase
@@ -27,10 +29,12 @@ internal sealed class PropertyStubSetup : SetupBase
         }
     }
 
-    internal override void VerifyMatched()
+    internal override void VerifyMatched(Predicate<SetupBase> predicate, HashSet<IMimic> verified)
     {
         // intentionally empty
     }
+
+    internal override IReadOnlyList<IMimic> GetNested() => (_currentValue as IMimicked)?.Mimic is { } mimic ? [mimic] : [];
 
     private sealed class PropertyStubExpectation : IExpectation
     {
@@ -48,5 +52,12 @@ internal sealed class PropertyStubSetup : SetupBase
 
         public bool MatchesInvocation(Invocation invocation)
             => invocation.Method.Name == _getter.Name || invocation.Method.Name == _setter.Name;
+
+        public override bool Equals(object? obj) => obj is PropertyStubExpectation other &&  Equals(other);
+
+        public bool Equals(IExpectation? obj) =>
+            obj is PropertyStubExpectation other && ExpressionEqualityComparer.Default.Equals(Expression, other.Expression);
+
+        public override int GetHashCode() => typeof(PropertyStubExpectation).GetHashCode();
     }
 }

--- a/src/Mimic/Setup/SetupBase.cs
+++ b/src/Mimic/Setup/SetupBase.cs
@@ -48,11 +48,16 @@ internal abstract class SetupBase
 
     public void FlagAsExpected() => _flags |= Flags.Expected;
 
-    internal virtual void VerifyMatched()
+    internal virtual void VerifyMatched(Predicate<SetupBase> predicate, HashSet<IMimic> verified)
     {
         if (!Matched)
             throw MimicException.ExpectedSetupNotMatched(this);
+
+        foreach (var nested in GetNested())
+            nested.VerifyReceived(predicate, verified);
     }
+
+    internal virtual IReadOnlyList<IMimic> GetNested() => [];
 
     public override string ToString()
     {

--- a/src/Mimic/Setup/SetupCollection.cs
+++ b/src/Mimic/Setup/SetupCollection.cs
@@ -1,0 +1,90 @@
+﻿namespace Mimic.Setup;
+
+internal sealed class SetupCollection : IReadOnlyList<SetupBase>
+{
+    private readonly List<SetupBase> _setups = [];
+    private readonly HashSet<IExpectation> _activeSetups = [];
+
+    public void Add(SetupBase setup)
+    {
+        lock (_setups)
+        {
+            _setups.Add(setup);
+
+            if (!_activeSetups.Add(setup.Expectation))
+                MarkOverridenSetups();
+        }
+    }
+
+    public List<SetupBase> FindAll(Predicate<SetupBase> predicate)
+    {
+        lock (_setups)
+            return _setups.Where(setup => !setup.Overridden && predicate(setup)).ToList();
+    }
+
+    public SetupBase? FindLast(Predicate<SetupBase> predicate)
+    {
+        lock (_setups)
+        {
+            if (_setups.Count == 0)
+                return null;
+
+            for (int i = _setups.Count - 1; i >= 0 ; i--)
+            {
+                var setup = _setups[i];
+                if (setup.Overridden)
+                    continue;
+
+                if (predicate(setup))
+                    return setup;
+            }
+        }
+
+        return null;
+    }
+
+    public int Count
+    {
+        get
+        {
+            lock (_setups)
+                return _setups.Count;
+        }
+    }
+
+    public SetupBase this[int index]
+    {
+        get
+        {
+            lock (_setups)
+            {
+                return _setups[index];
+            }
+        }
+    }
+
+    public IEnumerator<SetupBase> GetEnumerator()
+    {
+        lock (_setups)
+        {
+            return _setups.ToList().GetEnumerator();
+        }
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private void MarkOverridenSetups()
+    {
+        var visitedExpectations = new HashSet<IExpectation>();
+
+        for (int i = _setups.Count - 1; i >= 0 ; i--)
+        {
+            var setup = _setups[i];
+            if (setup.Overridden)
+                continue;
+
+            if (!visitedExpectations.Add(setup.Expectation))
+                setup.Override();
+        }
+    }
+}


### PR DESCRIPTION
Adds support for implicitly mimicking return values in nested setups. Where previously this wasn't possible.

For example, you would now be able to set up this nested method in a single call to `.Setup(...)`:

```cs
mimic.Setup(m => m.Method().NestedMethod())
    .Returns("Hello from nested method");
```