### PR TITLE
feat: Add `WithDelay` method to allow setting up delays for function invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ mimic.VerifyReceived(m => m.IsMimicEasyToUse("it's so intuitive"), CallCount.AtL
 Considering = ❓ | Planned = 📅 | In-Progress = 🚧
 ```
 
-- [📅] Delay behaviour (or Extension to `Returns`/`Throws`) for setups that allows for specific or random delays in
-  execution time
 - [❓] Setup and Verification of Event's
 - [❓] Configurable default return values instead of just `null` for reference and `default` for value types when
   `Strict = false`

--- a/src/Mimic.Sandbox/Program.cs
+++ b/src/Mimic.Sandbox/Program.cs
@@ -1,4 +1,5 @@
-﻿using Mimic;
+﻿using System.Diagnostics;
+using Mimic;
 
 var mimic = new Mimic<ITypeToMimic>();
 
@@ -32,6 +33,14 @@ reference.Throws(new Exception("Test Exception from void?"));
 mimic.SetupAllProperties();
 
 mimic.Setup(m => m.Generic<Generic.AnyType>())
+    .WithDelay(TimeSpan.FromMilliseconds(400))
+    .Expected();
+
+mimic.Setup(m => m.Generic<string>())
+    .WithDelay(TimeSpan.FromMilliseconds(800), TimeSpan.FromMilliseconds(1600))
+    .Expected();
+
+mimic.Setup(m => m.Generic<byte>())
     .Expected();
 
 SetupRef(mimic);
@@ -81,7 +90,17 @@ catch (Exception ex)
     Console.WriteLine($"Exception thrown with message: {ex.Message}");
 }
 
+var sw = Stopwatch.StartNew();
 mimickedObject.Generic<int>();
+Console.WriteLine($"Time taken with int {sw.ElapsedMilliseconds}ms");
+
+sw = Stopwatch.StartNew();
+mimickedObject.Generic<string>();
+Console.WriteLine($"Time taken with string {sw.ElapsedMilliseconds}ms");
+
+sw = Stopwatch.StartNew();
+mimickedObject.Generic<byte>();
+Console.WriteLine($"Time taken with byte {sw.ElapsedMilliseconds}ms");
 
 int refInt = 10;
 mimickedObject.Ref(ref refInt, out string outResult);

--- a/src/Mimic.UnitTests/Extensions/DelayableExtensionsTests.cs
+++ b/src/Mimic.UnitTests/Extensions/DelayableExtensionsTests.cs
@@ -1,0 +1,67 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+
+namespace Mimic.UnitTests.Extensions;
+
+public static class DelayableExtensionsTests
+{
+    [Theory, AutoData]
+    public static void WithDelay_ForDelayable_UsingSharedRandom_ShouldApplyRandomDelayBetweenMiniumAndMaximum(
+        [Range(100 ,500)] int fromMilliseconds, [Range(501, 1000)] int toMilliseconds)
+    {
+        var mimic = new Mimic<MimicTests.ISubject>();
+
+        mimic.Setup(m => m.ConditionalMethod())
+            .Returns("After Delay")
+            .WithDelay(TimeSpan.FromMilliseconds(fromMilliseconds), TimeSpan.FromMilliseconds(toMilliseconds));
+
+        var stopwatch = Stopwatch.StartNew();
+        mimic.Object.ConditionalMethod();
+        stopwatch.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(fromMilliseconds);
+    }
+
+    [Theory, AutoData]
+    public static void WithDelay_ForDelayable_UsingSpecificRandom_ShouldApplyRandomDelayBetweenMiniumAndMaximum(
+        [Range(100 ,500)] int fromMilliseconds, [Range(501, 1000)] int toMilliseconds)
+    {
+        var mimic = new Mimic<MimicTests.ISubject>();
+
+        mimic.Setup(m => m.ConditionalMethod())
+            .Returns("After Delay")
+            .WithDelay(TimeSpan.FromMilliseconds(fromMilliseconds), TimeSpan.FromMilliseconds(toMilliseconds), new Random());
+
+        var stopwatch = Stopwatch.StartNew();
+        mimic.Object.ConditionalMethod();
+        stopwatch.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(fromMilliseconds);
+    }
+
+    [Theory, AutoData]
+    public static void WithDelay_ForSequenceDelayable_UsingSharedRandom_ShouldApplyRandomDelayBetweenMiniumAndMaximum(
+        [Range(100 ,500)] int fromMilliseconds, [Range(501, 1000)] int toMilliseconds)
+    {
+        var mimic = new Mimic<MimicTests.ISubject>();
+
+        mimic.Setup(m => m.ConditionalMethod()).AsSequence()
+            .Returns("After Delay")
+            .WithDelay(TimeSpan.FromMilliseconds(fromMilliseconds), TimeSpan.FromMilliseconds(toMilliseconds));
+
+        var stopwatch = Stopwatch.StartNew();
+        mimic.Object.ConditionalMethod();
+        stopwatch.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(fromMilliseconds);
+    }
+
+    [Theory, AutoData]
+    public static void WithDelay_ForSequenceDelayable_UsingSpecificRandom_ShouldApplyRandomDelayBetweenMiniumAndMaximum(
+        [Range(100 ,500)] int fromMilliseconds, [Range(501, 1000)] int toMilliseconds)
+    {
+        var mimic = new Mimic<MimicTests.ISubject>();
+
+        mimic.Setup(m => m.ConditionalMethod()).AsSequence()
+            .Returns("After Delay")
+            .WithDelay(TimeSpan.FromMilliseconds(fromMilliseconds), TimeSpan.FromMilliseconds(toMilliseconds), new Random());
+
+        var stopwatch = Stopwatch.StartNew();
+        mimic.Object.ConditionalMethod();
+        stopwatch.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(fromMilliseconds);
+    }
+}

--- a/src/Mimic.UnitTests/Setup/Behaviours/DelayBehaviourTests.cs
+++ b/src/Mimic.UnitTests/Setup/Behaviours/DelayBehaviourTests.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using Mimic.Setup.Behaviours;
+
+namespace Mimic.UnitTests.Setup.Behaviours;
+
+public class DelayBehaviourTests
+{
+    [Theory, AutoData]
+    public void Execute_ReturnsAfterRoughlyTheSpecifiedTimeSpanHasElapsed(
+        [Range(100, 1000)] int firstDelayMs, [Range(100, 1000)] int secondDelayMs)
+    {
+        var invocation = new InvocationFixture();
+
+        var behaviour = new DelayBehaviour(execution => TimeSpan.FromMilliseconds(execution == 1 ? firstDelayMs : secondDelayMs));
+
+        var stopwatch = Stopwatch.StartNew();
+        behaviour.Execute(invocation);
+        stopwatch.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(firstDelayMs);
+
+        stopwatch = Stopwatch.StartNew();
+        behaviour.Execute(invocation);
+        stopwatch.ElapsedMilliseconds.ShouldBeGreaterThanOrEqualTo(secondDelayMs);
+    }
+}

--- a/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests.cs
@@ -335,6 +335,28 @@ public class SequenceSetupTests
         (methodCallSetup.ConfiguredBehaviours.ReturnOrThrow as SequenceBehaviour)!.Remaining.ShouldBe(1);
     }
 
+    [Theory, AutoData]
+    public void WithDelay_WhenCalledWithValue_ShouldCorrectlySetDelayBehaviour(int milliseconds)
+    {
+        var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
+        var setup = new SequenceSetup(methodCallSetup);
+
+        setup.WithDelay(TimeSpan.FromMilliseconds(milliseconds)).ShouldBeSameAs(setup);
+
+        methodCallSetup.ConfiguredBehaviours.Delay.ShouldNotBeNull();
+    }
+
+    [Theory, AutoData]
+    public void WithDelay_WhenCalledWithFunction_ShouldCorrectlySetDelayBehaviour(int milliseconds)
+    {
+        var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
+        var setup = new SequenceSetup(methodCallSetup);
+
+        setup.WithDelay(_ => TimeSpan.FromMilliseconds(milliseconds)).ShouldBeSameAs(setup);
+
+        methodCallSetup.ConfiguredBehaviours.Delay.ShouldNotBeNull();
+    }
+
     private static MethodCallSetup ToMethodCallSetup(Expression<Action<ISubject>> expression) => ToMethodCallSetup<ISubject>(expression);
 
     private static MethodCallSetup ToMethodCallSetup<T>(Expression<Action<T>> expression)

--- a/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests`1.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SequenceSetupTests`1.cs
@@ -574,6 +574,28 @@ public class SequenceSetupOfTResultTests
         (methodCallSetup.ConfiguredBehaviours.ReturnOrThrow as SequenceBehaviour)!.Remaining.ShouldBe(1);
     }
 
+    [Theory, AutoData]
+    public void WithDelay_WhenCalledWithValue_ShouldCorrectlySetDelayBehaviour(int milliseconds)
+    {
+        var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
+        var setup = new SequenceSetup(methodCallSetup);
+
+        setup.WithDelay(TimeSpan.FromMilliseconds(milliseconds)).ShouldBeSameAs(setup);
+
+        methodCallSetup.ConfiguredBehaviours.Delay.ShouldNotBeNull();
+    }
+
+    [Theory, AutoData]
+    public void WithDelay_WhenCalledWithFunction_ShouldCorrectlySetDelayBehaviour(int milliseconds)
+    {
+        var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
+        var setup = new SequenceSetup(methodCallSetup);
+
+        setup.WithDelay(_ => TimeSpan.FromMilliseconds(milliseconds)).ShouldBeSameAs(setup);
+
+        methodCallSetup.ConfiguredBehaviours.Delay.ShouldNotBeNull();
+    }
+
     private static MethodCallSetup ToMethodCallSetup(Expression<Action<ISubject>> expression) => ToMethodCallSetup<ISubject>(expression);
 
     private static MethodCallSetup ToMethodCallSetup<T>(Expression<Action<T>> expression)

--- a/src/Mimic.UnitTests/Setup/Fluent/SetupTests`1.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SetupTests`1.cs
@@ -523,6 +523,28 @@ public static partial class SetupTests
 
         #endregion
 
+        [Theory, AutoData]
+        public void WithDelay_WhenCalledWithValue_ShouldCorrectlySetDelayBehaviour(int milliseconds)
+        {
+            var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
+            var setup = new Setup<ISubject>(methodCallSetup);
+
+            setup.WithDelay(TimeSpan.FromMilliseconds(milliseconds)).ShouldBeSameAs(setup);
+
+            methodCallSetup.ConfiguredBehaviours.Delay.ShouldNotBeNull();
+        }
+
+        [Theory, AutoData]
+        public void WithDelay_WhenCalledWithFunction_ShouldCorrectlySetDelayBehaviour(int milliseconds)
+        {
+            var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
+            var setup = new Setup<ISubject>(methodCallSetup);
+
+            setup.WithDelay(_ => TimeSpan.FromMilliseconds(milliseconds)).ShouldBeSameAs(setup);
+
+            methodCallSetup.ConfiguredBehaviours.Delay.ShouldNotBeNull();
+        }
+
         [Theory]
         [AutoData]
         public void Limit_ShouldCorrectlySetExecutionLimitBehaviour(int executionLimit)

--- a/src/Mimic.UnitTests/Setup/Fluent/SetupTests`2.cs
+++ b/src/Mimic.UnitTests/Setup/Fluent/SetupTests`2.cs
@@ -534,6 +534,28 @@ public static partial class SetupTests
 
         #endregion
 
+        [Theory, AutoData]
+        public void WithDelay_WhenCalledWithValue_ShouldCorrectlySetDelayBehaviour(int milliseconds)
+        {
+            var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
+            var setup = new Setup<ISubject>(methodCallSetup);
+
+            setup.WithDelay(TimeSpan.FromMilliseconds(milliseconds)).ShouldBeSameAs(setup);
+
+            methodCallSetup.ConfiguredBehaviours.Delay.ShouldNotBeNull();
+        }
+
+        [Theory, AutoData]
+        public void WithDelay_WhenCalledWithFunction_ShouldCorrectlySetDelayBehaviour(int milliseconds)
+        {
+            var methodCallSetup = ToMethodCallSetup(m => m.MethodWithNoParameters());
+            var setup = new Setup<ISubject>(methodCallSetup);
+
+            setup.WithDelay(_ => TimeSpan.FromMilliseconds(milliseconds)).ShouldBeSameAs(setup);
+
+            methodCallSetup.ConfiguredBehaviours.Delay.ShouldNotBeNull();
+        }
+
         [Theory]
         [AutoData]
         public void Limit_ShouldCorrectlySetExecutionLimitBehaviour(int executionLimit)

--- a/src/Mimic/Extensions/DelayableExtensions.cs
+++ b/src/Mimic/Extensions/DelayableExtensions.cs
@@ -1,0 +1,42 @@
+﻿namespace Mimic;
+
+[PublicAPI]
+public static class DelayableExtensions
+{
+    #region IDelayable
+
+    public static IDelayableResult WithDelay(this IDelayable mimic, TimeSpan minDelay, TimeSpan maxDelay)
+    {
+        return mimic.WithDelay(minDelay, maxDelay, Random.Shared);
+    }
+
+    public static IDelayableResult WithDelay(this IDelayable mimic, TimeSpan minDelay, TimeSpan maxDelay, Random random)
+    {
+        Guard.Assert(minDelay < maxDelay, $"{nameof(minDelay)} must be less than {nameof(maxDelay)}");
+        Guard.NotNull(random);
+
+        return mimic.WithDelay(_ => GetRandomDelay(random, minDelay, maxDelay));
+    }
+
+    #endregion
+
+    #region ISequenceDelayable
+
+    public static IExpected WithDelay(this ISequenceDelayable mimic, TimeSpan minDelay, TimeSpan maxDelay)
+    {
+        return mimic.WithDelay(minDelay, maxDelay, Random.Shared);
+    }
+
+    public static IExpected WithDelay(this ISequenceDelayable mimic, TimeSpan minDelay, TimeSpan maxDelay, Random random)
+    {
+        Guard.Assert(minDelay < maxDelay, $"{nameof(minDelay)} must be less than {nameof(maxDelay)}");
+        Guard.NotNull(random);
+
+        return mimic.WithDelay(_ => GetRandomDelay(random, minDelay, maxDelay));
+    }
+
+    #endregion
+
+    private static TimeSpan GetRandomDelay(Random random, TimeSpan minDelay, TimeSpan maxDelay) =>
+        new(random.Next((int)minDelay.Ticks, (int)maxDelay.Ticks));
+}

--- a/src/Mimic/Fluent/ICallbackResult.cs
+++ b/src/Mimic/Fluent/ICallbackResult.cs
@@ -2,4 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ICallbackResult : IThrows, IThrowsResult, ILimitable, IExpected, IFluent;
+public interface ICallbackResult : IThrows, IThrowsResult, IDelayable, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/ICallbackResult`1.cs
+++ b/src/Mimic/Fluent/ICallbackResult`1.cs
@@ -2,4 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ICallbackResult<in TResult> : IReturns<TResult>, IThrows, ILimitable, IExpected, IFluent;
+public interface ICallbackResult<in TResult> : IReturns<TResult>, IThrows, IDelayable, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/IDelayable.cs
+++ b/src/Mimic/Fluent/IDelayable.cs
@@ -1,0 +1,10 @@
+﻿namespace Mimic;
+
+[PublicAPI]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface IDelayable : IFluent
+{
+    IDelayableResult WithDelay(TimeSpan delay);
+
+    IDelayableResult WithDelay(Func<int, TimeSpan> delayFunction);
+}

--- a/src/Mimic/Fluent/IDelayableResult.cs
+++ b/src/Mimic/Fluent/IDelayableResult.cs
@@ -1,0 +1,5 @@
+namespace Mimic;
+
+[PublicAPI]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface IDelayableResult : ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/IGetterCallbackResult`1.cs
+++ b/src/Mimic/Fluent/IGetterCallbackResult`1.cs
@@ -2,4 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IGetterCallbackResult<in TProperty> : IGetterReturns<TProperty>, IThrows, ILimitable, IExpected, IFluent;
+public interface IGetterCallbackResult<in TProperty> : IGetterReturns<TProperty>, IThrows, IDelayable, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/IGetterSetup`2.cs
+++ b/src/Mimic/Fluent/IGetterSetup`2.cs
@@ -2,4 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IGetterSetup<TMimic, in TProperty> : IGetterCallback<TProperty>,  IGetterReturns<TProperty>, IThrows, ILimitable, IExpected, IFluent;
+public interface IGetterSetup<TMimic, in TProperty> : IGetterCallback<TProperty>,  IGetterReturns<TProperty>, IThrows, IDelayable, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/IReturnsResult.cs
+++ b/src/Mimic/Fluent/IReturnsResult.cs
@@ -2,4 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IReturnsResult : ICallback, ILimitable, IExpected, IFluent;
+public interface IReturnsResult : ICallback, IDelayable, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Fluent/ISequenceDelayable.cs
+++ b/src/Mimic/Fluent/ISequenceDelayable.cs
@@ -1,0 +1,10 @@
+namespace Mimic;
+
+[PublicAPI]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public interface ISequenceDelayable : IFluent
+{
+    IExpected WithDelay(TimeSpan delay);
+
+    IExpected WithDelay(Func<int, TimeSpan> delayFunction);
+}

--- a/src/Mimic/Fluent/ISequenceSetup.cs
+++ b/src/Mimic/Fluent/ISequenceSetup.cs
@@ -2,7 +2,7 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ISequenceSetup : IThrows<ISequenceSetup>, IExpected, IFluent
+public interface ISequenceSetup : IThrows<ISequenceSetup>, ISequenceDelayable, IExpected, IFluent
 {
     ISequenceSetup Proceed();
 

--- a/src/Mimic/Fluent/ISequenceSetup`1.cs
+++ b/src/Mimic/Fluent/ISequenceSetup`1.cs
@@ -2,4 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ISequenceSetup<in TResult> : IReturns<TResult, ISequenceSetup<TResult>>, IThrows<ISequenceSetup<TResult>>, IExpected, IFluent;
+public interface ISequenceSetup<in TResult> : IReturns<TResult, ISequenceSetup<TResult>>, IThrows<ISequenceSetup<TResult>>, ISequenceDelayable, IExpected, IFluent;

--- a/src/Mimic/Fluent/ISetterCallback`1.cs
+++ b/src/Mimic/Fluent/ISetterCallback`1.cs
@@ -2,7 +2,7 @@ namespace Mimic;
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ISetterCallback<out TProperty> : ILimitable, IExpected, IFluent
+public interface ISetterCallback<out TProperty> : IDelayable, ILimitable, IExpected, IFluent
 {
     ICallbackResult Callback(Action<TProperty> callback);
 }

--- a/src/Mimic/Fluent/ISetterSetup`2.cs
+++ b/src/Mimic/Fluent/ISetterSetup`2.cs
@@ -2,5 +2,5 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ISetterSetup<TMimic, out TProperty> : ISetterCallback<TProperty>, ILimitable, IExpected, IFluent
+public interface ISetterSetup<TMimic, out TProperty> : ISetterCallback<TProperty>, IDelayable, ILimitable, IExpected, IFluent
     where TMimic : class;

--- a/src/Mimic/Fluent/ISetup`1.cs
+++ b/src/Mimic/Fluent/ISetup`1.cs
@@ -2,7 +2,7 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ISetup<TMimic> : ICallback, IProceed, IThrows, ILimitable, IExpected, IFluent
+public interface ISetup<TMimic> : ICallback, IProceed, IThrows, IDelayable, ILimitable, IExpected, IFluent
     where TMimic : class
 {
     ISequenceSetup AsSequence();

--- a/src/Mimic/Fluent/ISetup`2.cs
+++ b/src/Mimic/Fluent/ISetup`2.cs
@@ -2,7 +2,7 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface ISetup<TMimic, in TResult> : ICallback<TResult>, IReturns<TResult>, ILimitable, IThrows, IExpected, IFluent
+public interface ISetup<TMimic, in TResult> : ICallback<TResult>, IReturns<TResult>, IDelayable, ILimitable, IThrows, IExpected, IFluent
     where TMimic : class
 {
     ISequenceSetup<TResult> AsSequence();

--- a/src/Mimic/Fluent/IThrowsResult.cs
+++ b/src/Mimic/Fluent/IThrowsResult.cs
@@ -2,4 +2,4 @@
 
 [PublicAPI]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public interface IThrowsResult : ILimitable, IExpected, IFluent;
+public interface IThrowsResult : IDelayable, ILimitable, IExpected, IFluent;

--- a/src/Mimic/Setup/Behaviours/DelayBehaviour.cs
+++ b/src/Mimic/Setup/Behaviours/DelayBehaviour.cs
@@ -1,0 +1,17 @@
+﻿namespace Mimic.Setup.Behaviours;
+
+internal sealed class DelayBehaviour : Behaviour
+{
+    private readonly Func<int, TimeSpan> _delayFunction;
+    private int _executionCount;
+
+    public DelayBehaviour(Func<int, TimeSpan> delayFunction) => _delayFunction = delayFunction;
+
+    internal override void Execute(Invocation invocation)
+    {
+        _executionCount++;
+
+        var delay = _delayFunction.Invoke(_executionCount);
+        Thread.Sleep(delay);
+    }
+}

--- a/src/Mimic/Setup/Fluent/SequenceSetupBase.cs
+++ b/src/Mimic/Setup/Fluent/SequenceSetupBase.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mimic.Setup.Fluent;
 
-internal abstract class SequenceSetupBase<TNext> : IThrows<TNext>, IExpected
+internal abstract class SequenceSetupBase<TNext> : IThrows<TNext>, ISequenceDelayable, IExpected
     where TNext : IFluent
 {
     protected MethodCallSetup Setup { get; }
@@ -156,6 +156,18 @@ internal abstract class SequenceSetupBase<TNext> : IThrows<TNext>, IExpected
     {
         Setup.AddProceedBehaviour();
         return This;
+    }
+
+    public IExpected WithDelay(TimeSpan delay)
+    {
+        Setup.SetDelayBehaviour(_ => delay);
+        return this;
+    }
+
+    public IExpected WithDelay(Func<int, TimeSpan> delayFunction)
+    {
+        Setup.SetDelayBehaviour(delayFunction);
+        return this;
     }
 
     public void Expected() => Setup.FlagAsExpected();

--- a/src/Mimic/Setup/Fluent/SetupBase.cs
+++ b/src/Mimic/Setup/Fluent/SetupBase.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mimic.Setup.Fluent;
 
-internal class SetupBase : ICallback, ICallbackResult, IThrows, IThrowsResult
+internal class SetupBase : ICallback, ICallbackResult, IThrows, IThrowsResult, IDelayableResult
 {
     protected SetupBase(MethodCallSetup setup)
     {
@@ -264,6 +264,18 @@ internal class SetupBase : ICallback, ICallbackResult, IThrows, IThrowsResult
     }
 
     #endregion
+
+    public IDelayableResult WithDelay(TimeSpan delay)
+    {
+        Setup.SetDelayBehaviour(_ => delay);
+        return this;
+    }
+
+    public IDelayableResult WithDelay(Func<int, TimeSpan> delayFunction)
+    {
+        Setup.SetDelayBehaviour(delayFunction);
+        return this;
+    }
 
     public IExpected Limit(int executionLimit = 1)
     {


### PR DESCRIPTION
Adds a new method `WithDelay()` on all setups, which allows you to configure an execution delay (or processing time) for a mocked function when called.

Usage example:
```cs
mimic.Setup(m => m.Method())
    .Returns("Delayed result")
    .WithDelay(TimeSpan.FromMilliseconds(300));
```

Usage example (Sequence):
```cs
mimic.Setup(m => m.SequenceMethod()).AsSequence()
    .Returns("Delayed Result")
    .Throws(new Exception("Delayed Exception"))
    .WithDelay((invocationCount) => TimeSpan.FromSeconds(invocationCount));
```