### PR TITLE
feat: Add missed 16-parameter overloads in `ReturnsExtensions`

### DIFF
--- a/src/Mimic.UnitTests/Extensions/ReturnsExtensionsTests.cs
+++ b/src/Mimic.UnitTests/Extensions/ReturnsExtensionsTests.cs
@@ -355,6 +355,36 @@ public static class ReturnsExtensionsTests
 
             (await mimic.Object.Task(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)).ShouldBe(value);
         }
+
+        [Theory, AutoData]
+        public static async Task Returns_WithSixteenParamsAndValueFunction_ShouldReturnValue(int value, int t1, int t2, int t3, int t4, int t5, int t6, int t7, int t8, int t9, int t10, int t11, int t12, int t13, int t14, int t15, int t16)
+        {
+            var mimic = new Mimic<ISubject>();
+
+            mimic.Setup(m => m.Task(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16))
+                .Returns((int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16) =>
+                {
+                    a1.ShouldBe(t1);
+                    a2.ShouldBe(t2);
+                    a3.ShouldBe(t3);
+                    a4.ShouldBe(t4);
+                    a5.ShouldBe(t5);
+                    a6.ShouldBe(t6);
+                    a7.ShouldBe(t7);
+                    a8.ShouldBe(t8);
+                    a9.ShouldBe(t9);
+                    a10.ShouldBe(t10);
+                    a11.ShouldBe(t11);
+                    a12.ShouldBe(t12);
+                    a13.ShouldBe(t13);
+                    a14.ShouldBe(t14);
+                    a15.ShouldBe(t15);
+                    a16.ShouldBe(t16);
+                    return value;
+                });
+
+            (await mimic.Object.Task(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)).ShouldBe(value);
+        }
     }
 
     public static class ValueTaskOfT
@@ -710,6 +740,36 @@ public static class ReturnsExtensionsTests
 
             (await mimic.Object.ValueTask(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)).ShouldBe(value);
         }
+
+        [Theory, AutoData]
+        public static async Task Returns_WithSixteenParamsAndValueFunction_ShouldReturnValue(int value, int t1, int t2, int t3, int t4, int t5, int t6, int t7, int t8, int t9, int t10, int t11, int t12, int t13, int t14, int t15, int t16)
+        {
+            var mimic = new Mimic<ISubject>();
+
+            mimic.Setup(m => m.ValueTask(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16))
+                .Returns((int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15, int a16) =>
+                {
+                    a1.ShouldBe(t1);
+                    a2.ShouldBe(t2);
+                    a3.ShouldBe(t3);
+                    a4.ShouldBe(t4);
+                    a5.ShouldBe(t5);
+                    a6.ShouldBe(t6);
+                    a7.ShouldBe(t7);
+                    a8.ShouldBe(t8);
+                    a9.ShouldBe(t9);
+                    a10.ShouldBe(t10);
+                    a11.ShouldBe(t11);
+                    a12.ShouldBe(t12);
+                    a13.ShouldBe(t13);
+                    a14.ShouldBe(t14);
+                    a15.ShouldBe(t15);
+                    a16.ShouldBe(t16);
+                    return value;
+                });
+
+            (await mimic.Object.ValueTask(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)).ShouldBe(value);
+        }
     }
 
     // ReSharper disable once MemberCanBePrivate.Global
@@ -747,6 +807,8 @@ public static class ReturnsExtensionsTests
 
         public Task<int> Task(int t1, int t2, int t3, int t4, int t5, int t6, int t7, int t8, int t9, int t10, int t11, int t12, int t13, int t14, int t15);
 
+        public Task<int> Task(int t1, int t2, int t3, int t4, int t5, int t6, int t7, int t8, int t9, int t10, int t11, int t12, int t13, int t14, int t15, int t16);
+
         public ValueTask<int> ValueTask();
 
         public ValueTask<int> ValueTask(int t);
@@ -778,5 +840,7 @@ public static class ReturnsExtensionsTests
         public ValueTask<int> ValueTask(int t1, int t2, int t3, int t4, int t5, int t6, int t7, int t8, int t9, int t10, int t11, int t12, int t13, int t14);
 
         public ValueTask<int> ValueTask(int t1, int t2, int t3, int t4, int t5, int t6, int t7, int t8, int t9, int t10, int t11, int t12, int t13, int t14, int t15);
+
+        public ValueTask<int> ValueTask(int t1, int t2, int t3, int t4, int t5, int t6, int t7, int t8, int t9, int t10, int t11, int t12, int t13, int t14, int t15, int t16);
     }
 }

--- a/src/Mimic/Extensions/ReturnsExtensions.cs
+++ b/src/Mimic/Extensions/ReturnsExtensions.cs
@@ -409,11 +409,45 @@ public static class ReturnsExtensions
     /// <returns>An <see cref="IReturnsResult"/> that can be used to configure additional return behaviours.</returns>
     /// <remarks>
     /// This method allows the return value to be computed based on the method's arguments while automatically handling the task wrapping.
-    /// This is the maximum parameter count supported by these extension methods.
+    /// The function receives the arguments passed to the mocked method at invocation time.
     /// </remarks>
     public static IReturnsResult Returns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this IReturns<Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> valueFunction)
     {
         return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)));
+    }
+
+    /// <summary>
+    /// Configures the setup to return a value computed by the specified function using the method's sixteen arguments,
+    /// wrapped in a completed <see cref="Task{TResult}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the method's first argument.</typeparam>
+    /// <typeparam name="T2">The type of the method's second argument.</typeparam>
+    /// <typeparam name="T3">The type of the method's third argument.</typeparam>
+    /// <typeparam name="T4">The type of the method's fourth argument.</typeparam>
+    /// <typeparam name="T5">The type of the method's fifth argument.</typeparam>
+    /// <typeparam name="T6">The type of the method's sixth argument.</typeparam>
+    /// <typeparam name="T7">The type of the method's seventh argument.</typeparam>
+    /// <typeparam name="T8">The type of the method's eighth argument.</typeparam>
+    /// <typeparam name="T9">The type of the method's ninth argument.</typeparam>
+    /// <typeparam name="T10">The type of the method's tenth argument.</typeparam>
+    /// <typeparam name="T11">The type of the method's eleventh argument.</typeparam>
+    /// <typeparam name="T12">The type of the method's twelfth argument.</typeparam>
+    /// <typeparam name="T13">The type of the method's thirteenth argument.</typeparam>
+    /// <typeparam name="T14">The type of the method's fourteenth argument.</typeparam>
+    /// <typeparam name="T15">The type of the method's fifteenth argument.</typeparam>
+    /// <typeparam name="T16">The type of the method's sixteenth argument.</typeparam>
+    /// <typeparam name="TResult">The type of the value to be returned.</typeparam>
+    /// <param name="mimic">The returns configuration instance.</param>
+    /// <param name="valueFunction">A function that takes the method's arguments and computes the return value.</param>
+    /// <returns>An <see cref="IReturnsResult"/> that can be used to configure additional return behaviours.</returns>
+    /// <remarks>
+    /// This method allows the return value to be computed based on the method's arguments while automatically handling the task wrapping.
+    /// The function receives the arguments passed to the mocked method at invocation time.
+    /// This is the maximum parameter count supported by these extension methods.
+    /// </remarks>
+    public static IReturnsResult Returns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this IReturns<Task<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> valueFunction)
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15, T16 t16) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)));
     }
 
     #endregion
@@ -821,11 +855,45 @@ public static class ReturnsExtensions
     /// <returns>An <see cref="IReturnsResult"/> that can be used to configure additional return behaviours.</returns>
     /// <remarks>
     /// This method allows the return value to be computed based on the method's arguments while automatically handling the ValueTask wrapping.
-    /// This is the maximum parameter count supported by these extension methods.
+    /// The function receives the arguments passed to the mocked method at invocation time.
     /// </remarks>
     public static IReturnsResult Returns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult>(this IReturns<ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> valueFunction)
     {
         return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)));
+    }
+
+    /// <summary>
+    /// Configures the setup to return a value computed by the specified function using the method's sixteen arguments,
+    /// wrapped in a <see cref="ValueTask{TResult}"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the method's first argument.</typeparam>
+    /// <typeparam name="T2">The type of the method's second argument.</typeparam>
+    /// <typeparam name="T3">The type of the method's third argument.</typeparam>
+    /// <typeparam name="T4">The type of the method's fourth argument.</typeparam>
+    /// <typeparam name="T5">The type of the method's fifth argument.</typeparam>
+    /// <typeparam name="T6">The type of the method's sixth argument.</typeparam>
+    /// <typeparam name="T7">The type of the method's seventh argument.</typeparam>
+    /// <typeparam name="T8">The type of the method's eighth argument.</typeparam>
+    /// <typeparam name="T9">The type of the method's ninth argument.</typeparam>
+    /// <typeparam name="T10">The type of the method's tenth argument.</typeparam>
+    /// <typeparam name="T11">The type of the method's eleventh argument.</typeparam>
+    /// <typeparam name="T12">The type of the method's twelfth argument.</typeparam>
+    /// <typeparam name="T13">The type of the method's thirteenth argument.</typeparam>
+    /// <typeparam name="T14">The type of the method's fourteenth argument.</typeparam>
+    /// <typeparam name="T15">The type of the method's fifteenth argument.</typeparam>
+    /// <typeparam name="T16">The type of the method's sixteenth argument.</typeparam>
+    /// <typeparam name="TResult">The type of the value to be returned.</typeparam>
+    /// <param name="mimic">The returns configuration instance.</param>
+    /// <param name="valueFunction">A function that takes the method's arguments and computes the return value.</param>
+    /// <returns>An <see cref="IReturnsResult"/> that can be used to configure additional return behaviours.</returns>
+    /// <remarks>
+    /// This method allows the return value to be computed based on the method's arguments while automatically handling the ValueTask wrapping.
+    /// The function receives the arguments passed to the mocked method at invocation time.
+    /// This is the maximum parameter count supported by these extension methods.
+    /// </remarks>
+    public static IReturnsResult Returns<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult>(this IReturns<ValueTask<TResult>> mimic, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TResult> valueFunction)
+    {
+        return mimic.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15, T16 t16) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)));
     }
 
     #endregion


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mocking methods with up to sixteen parameters for both Task and ValueTask return types.

* **Tests**
  * Introduced new unit tests to verify correct handling and return values for methods with sixteen parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->